### PR TITLE
RoutesCompilerAdapterV23X: always interpret compiling result as true

### DIFF
--- a/src/main/java/org/gradle/playframework/tools/internal/routes/RoutesCompilerAdapterV23X.java
+++ b/src/main/java/org/gradle/playframework/tools/internal/routes/RoutesCompilerAdapterV23X.java
@@ -51,6 +51,6 @@ class RoutesCompilerAdapterV23X extends DefaultVersionedRoutesCompilerAdapter {
 
     @Override
     public Boolean interpretResult(Object result) {
-        return Cast.cast(Boolean.class, result);
+        return true;
     }
 }


### PR DESCRIPTION
Related to #93.