### PR TITLE
Fix deprecated code relying on ProjectLayout.configurableFiles()

### DIFF
--- a/src/main/java/org/gradle/playframework/tasks/JavaScriptMinify.java
+++ b/src/main/java/org/gradle/playframework/tasks/JavaScriptMinify.java
@@ -41,7 +41,7 @@ public class JavaScriptMinify extends SourceTask {
         this.workerExecutor = workerExecutor;
         this.include("**/*.js");
         destinationDir = getProject().getObjects().directoryProperty();
-        compilerClasspath = getProject().getLayout().configurableFiles();
+        compilerClasspath = getProject().getObjects().fileCollection();
     }
 
     /**

--- a/src/main/java/org/gradle/playframework/tasks/RoutesCompile.java
+++ b/src/main/java/org/gradle/playframework/tasks/RoutesCompile.java
@@ -59,7 +59,7 @@ public class RoutesCompile extends SourceTask {
         platform = getProject().getObjects().property(PlayPlatform.class);
         injectedRoutesGenerator = getProject().getObjects().property(Boolean.class);
         injectedRoutesGenerator.set(false);
-        routesCompilerClasspath = getProject().getLayout().configurableFiles();
+        routesCompilerClasspath = getProject().getObjects().fileCollection();
     }
 
     /**

--- a/src/main/java/org/gradle/playframework/tasks/TwirlCompile.java
+++ b/src/main/java/org/gradle/playframework/tasks/TwirlCompile.java
@@ -63,7 +63,7 @@ public class TwirlCompile extends SourceTask {
         defaultImports = getProject().getObjects().property(TwirlImports.class);
         userTemplateFormats = getProject().getObjects().listProperty(TwirlTemplateFormat.class).empty();
         additionalImports = getProject().getObjects().listProperty(String.class);
-        twirlCompilerClasspath = getProject().getLayout().configurableFiles();
+        twirlCompilerClasspath = getProject().getObjects().fileCollection();
     }
 
     /**


### PR DESCRIPTION
Hi,
I think this fix will make the plugin working only with Gradle 5.3 or newer.
In my humble opinion, it's acceptable while the plugin isn't very popular yet.

Have a nice day.