### PR TITLE
make playRun depend on mainJar and assetsJar tasks

### DIFF
--- a/src/main/java/org/gradle/playframework/plugins/PlayApplicationPlugin.java
+++ b/src/main/java/org/gradle/playframework/plugins/PlayApplicationPlugin.java
@@ -162,7 +162,7 @@ public class PlayApplicationPlugin implements Plugin<Project> {
             playRun.setApplicationJar(mainJarTask.get().getArchivePath());
             playRun.setAssetsJar(assetsJarTask.get().getArchivePath());
             playRun.setAssetsDirs(new HashSet<>(Arrays.asList(project.file("public"))));
-            playRun.dependsOn(project.getTasks().named(BUILD_TASK_NAME));
+            playRun.dependsOn(mainJarTask, assetsJarTask);
         });
     }
 


### PR DESCRIPTION
Under old playframework, executing runPlayBinary will not run test. However, under new playframwork, runPlay depends on build task, which will run test task. I think it is unnecessary. runPlay task just requires mainJarTask and assetsJarTask. 

More info, please refer to : https://github.com/gradle/playframework/issues/101

The following is my test (I attached the build scan and also the snapshot in case you couldn't access the build scan)
1. executing runPlayBinary under old playframework: [build scan](https://scans.gradle.com/s/boq4qqogyaoky/timeline)
snapshot: 
<img width="944" alt="Screen Shot 2019-06-20 at 10 13 41 AM" src="https://user-images.githubusercontent.com/11835698/59867922-5b47c480-9344-11e9-9238-3086e82a4d96.png">

2. executing runPlay under new playframework: [build scan](https://scans.gradle.com/s/kymuo4lddh2as/timeline)
<img width="852" alt="Screen Shot 2019-06-20 at 10 16 36 AM" src="https://user-images.githubusercontent.com/11835698/59867982-816d6480-9344-11e9-9399-7434336ac73e.png">

3. executing runPlay under new playFramework: [build scan](https://scans.gradle.com/s/33aufztxwgt4c/timeline)
<img width="859" alt="Screen Shot 2019-06-20 at 10 17 27 AM" src="https://user-images.githubusercontent.com/11835698/59868021-a366e700-9344-11e9-8fb5-9a456d71748b.png">

