### PR TITLE
Fix archive baseName

### DIFF
--- a/src/docTest/groovy/org/gradle/playframework/InDepthUserGuideSamplesIntegrationTest.groovy
+++ b/src/docTest/groovy/org/gradle/playframework/InDepthUserGuideSamplesIntegrationTest.groovy
@@ -42,7 +42,7 @@ abstract class InDepthUserGuideSamplesIntegrationTest extends Specification {
     }
 
     List<ArchiveTestFixture> distributionArchives(File sampleDir) {
-        [new ZipTestFixture(new File(sampleDir, "build/distributions/main.zip")),
-         new TarTestFixture(new File(sampleDir, "build/distributions/main.tar"))]
+        [new ZipTestFixture(new File(sampleDir, "build/distributions/custom-distribution.zip")),
+         new TarTestFixture(new File(sampleDir, "build/distributions/custom-distribution.tar"))]
     }
 }

--- a/src/docTest/groovy/org/gradle/playframework/MiscUserGuideIntegrationTest.groovy
+++ b/src/docTest/groovy/org/gradle/playframework/MiscUserGuideIntegrationTest.groovy
@@ -73,8 +73,8 @@ class MiscUserGuideIntegrationTest extends InDepthUserGuideSamplesIntegrationTes
 
         then:
         distributionArchives(sample.dir)*.containsDescendants(
-                "main/README.md",
-                "main/bin/runPlayBinaryAsUser.sh"
+                "custom-distribution/README.md",
+                "custom-distribution/bin/runPlayBinaryAsUser.sh"
         )
 
         where:

--- a/src/integTest/groovy/org/gradle/playframework/application/PlayDistributionApplicationIntegrationTest.groovy
+++ b/src/integTest/groovy/org/gradle/playframework/application/PlayDistributionApplicationIntegrationTest.groovy
@@ -51,20 +51,20 @@ abstract class PlayDistributionApplicationIntegrationTest extends PlayMultiVersi
     }
 
     List<ArchiveTestFixture> archives() {
-        [ zip("build/distributions/main.zip"), tar("build/distributions/main.tar") ]
+        [ zip("build/distributions/${playApp.name}.zip"), tar("build/distributions/${playApp.name}.tar") ]
     }
     void verifyArchives() {
         archives()*.containsDescendants(
-                "main/lib/${playApp.name}.jar",
-                "main/lib/${playApp.name}-assets.jar",
-                "main/bin/main",
-                "main/bin/main.bat",
-                "main/conf/application.conf",
-                "main/README")
+                "${playApp.name}/lib/${playApp.name}.jar",
+                "${playApp.name}/lib/${playApp.name}-assets.jar",
+                "${playApp.name}/bin/main",
+                "${playApp.name}/bin/main.bat",
+                "${playApp.name}/conf/application.conf",
+                "${playApp.name}/README")
     }
 
     void verifyStagedFiles() {
-        File stageMainDir = file("build/stage/main")
+        File stageMainDir = file("build/stage/${playApp.name}")
         [
             "lib/${playApp.name}.jar",
             "lib/${playApp.name}-assets.jar",
@@ -89,7 +89,7 @@ abstract class PlayDistributionApplicationIntegrationTest extends PlayMultiVersi
         // Verify that the Class-Path attribute contains the correct runtime classpath
         def classpath = mainJar.manifest.mainAttributes.getValue("Class-Path")
         def classpathAsFilenames = Arrays.asList(classpath.split(" "))
-        def dependencies = file("build/stage/main/lib/").listFiles().collect { it.name } - [ mainJar.file.name ]
+        def dependencies = file("build/stage/${playApp.name}/lib/").listFiles().collect { it.name } - [ mainJar.file.name ]
         assert dependencies.size() == classpathAsFilenames.size()
         assert classpathAsFilenames.containsAll(dependencies)
     }

--- a/src/integTest/groovy/org/gradle/playframework/application/advanced/PlayDistributionAdvancedAppIntegrationTest.groovy
+++ b/src/integTest/groovy/org/gradle/playframework/application/advanced/PlayDistributionAdvancedAppIntegrationTest.groovy
@@ -20,15 +20,15 @@ class PlayDistributionAdvancedAppIntegrationTest extends PlayDistributionApplica
         super.verifyArchives()
 
         archives()*.containsDescendants(
-                "main/conf/jva.routes",
-                "main/conf/scala.routes")
+                "${playApp.name}/conf/jva.routes",
+                "${playApp.name}/conf/scala.routes")
     }
 
     @Override
     void verifyStagedFiles() {
         super.verifyStagedFiles()
 
-        File stageMainDir = file("build/stage/main")
+        File stageMainDir = file("build/stage/${playApp.name}")
         [
             "conf/jva.routes",
             "conf/scala.routes"

--- a/src/integTest/groovy/org/gradle/playframework/tasks/DistributionZipIntegrationTest.groovy
+++ b/src/integTest/groovy/org/gradle/playframework/tasks/DistributionZipIntegrationTest.groovy
@@ -32,6 +32,6 @@ class DistributionZipIntegrationTest extends AbstractIntegrationTest {
         build "dist"
 
         then:
-        zip("build/distributions/main.zip").containsDescendants("main/additionalFile.txt")
+        zip("build/distributions/dist-play-app.zip").containsDescendants("dist-play-app/additionalFile.txt")
     }
 }

--- a/src/main/java/org/gradle/playframework/plugins/PlayDistributionPlugin.java
+++ b/src/main/java/org/gradle/playframework/plugins/PlayDistributionPlugin.java
@@ -187,11 +187,11 @@ public class PlayDistributionPlugin implements Plugin<Project> {
                 @Override
                 public String call() throws Exception {
                     String baseName = (String) Distribution.class.getMethod("getBaseName").invoke(distribution);
-                    return "".equals(baseName) ? "" : distribution.getName();
+                    return baseName != null && !baseName.isEmpty() ? baseName : distribution.getName();
                 }
             });
         } else {
-            return distribution.getDistributionBaseName().map(baseName -> baseName.isEmpty() ? "" : distribution.getName()).orElse(distribution.getName());
+            return distribution.getDistributionBaseName().map(baseName -> !baseName.isEmpty() ? baseName : distribution.getName()).orElse(distribution.getName());
         }
     }
 
@@ -238,7 +238,7 @@ public class PlayDistributionPlugin implements Plugin<Project> {
         public String apply(File input) {
             calculateRenames();
             String rename = renames.get(input);
-            if (rename!=null) {
+            if (rename != null) {
                 return rename;
             }
             return input.getName();


### PR DESCRIPTION
I found an odd condition in PlayDistributionPlugin:143 when browsing the plugin source code. I think I fixed the generated archives (zip & tar) base name.

I had to change some tests but it seems legitimate in this case.