### PR TITLE
Replace deprecated usage of AbstractArchiveTask.setClassifier

### DIFF
--- a/src/main/java/org/gradle/playframework/plugins/PlayApplicationPlugin.java
+++ b/src/main/java/org/gradle/playframework/plugins/PlayApplicationPlugin.java
@@ -126,7 +126,7 @@ public class PlayApplicationPlugin implements Plugin<Project> {
     private TaskProvider<Jar> createAssetsJarTask(Project project) {
         TaskProvider<Jar> assetsJarTask = project.getTasks().register(ASSETS_JAR_TASK_NAME, Jar.class, jar -> {
             jar.setDescription("Assembles the assets jar for the application.");
-            jar.setClassifier("assets");
+            jar.getArchiveClassifier().set("assets");
             jar.from(project.file("public"), copySpec -> copySpec.into("public"));
         });
 


### PR DESCRIPTION
This code fixes a Gradle 6 warning, see issue https://github.com/gradle/playframework/issues/114