### PR TITLE
Add link to GitHub repo in docs

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -3,7 +3,10 @@
 :uri-gradle-dsl-reference: https://docs.gradle.org/current/dsl
 :uri-ghpages: https://gradle.github.io/playframework
 :uri-plugin-api: {uri-ghpages}/api
-:uri-github-issues: https://github.com/gradle/playframework/issues
+:uri-github: https://github.com/gradle/playframework
+:uri-github-issues: {uri-github}/issues
+
+{uri-github}[Gradle Play Framework Github Repository]
 
 include::00-intro.adoc[]
 


### PR DESCRIPTION
I ended up running into quite a few times where I wanted to navigate from the docs to the GitHub repo but ended up having to use Google to do it instead of a link in the document because we don't have one currently.