### PR TITLE
Add a play-dependencies-plugin to help resolving dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,6 +60,13 @@ gradlePlugin {
             implementationClass = "org.gradle.playframework.plugins.PlayApplicationPlugin"
         }
 
+        register("play-dependencies-plugin") {
+            id = "org.gradle.playframework-dependencies"
+            displayName = "Play Dependencies Plugin"
+            description = "Plugin for adding Play dependencies."
+            implementationClass = "org.gradle.playframework.plugins.PlayDependenciesPlugin"
+        }
+
         register("play-javascript-plugin") {
             id = "org.gradle.playframework-javascript"
             displayName = "Play JavaScript Plugin"

--- a/src/integTest/groovy/org/gradle/playframework/PlayMultiVersionDependenciesIntegrationTest.groovy
+++ b/src/integTest/groovy/org/gradle/playframework/PlayMultiVersionDependenciesIntegrationTest.groovy
@@ -1,0 +1,17 @@
+package org.gradle.playframework
+
+import static org.gradle.playframework.fixtures.Repositories.playRepositories
+
+abstract class PlayMultiVersionDependenciesIntegrationTest extends PlayMultiVersionIntegrationTest {
+
+    def setup() {
+        buildFile << """
+            plugins {
+                id 'org.gradle.playframework'
+            }
+            
+            ${playRepositories()}
+        """
+        configurePlayVersionInBuildScript()
+    }
+}

--- a/src/integTest/groovy/org/gradle/playframework/plugins/PlayDependenciesPluginIntegrationTest.groovy
+++ b/src/integTest/groovy/org/gradle/playframework/plugins/PlayDependenciesPluginIntegrationTest.groovy
@@ -1,0 +1,22 @@
+package org.gradle.playframework.plugins
+
+import org.gradle.playframework.PlayMultiVersionDependenciesIntegrationTest
+
+import static org.gradle.playframework.fixtures.Repositories.playRepositories
+
+class PlayDependenciesPluginIntegrationTest extends PlayMultiVersionDependenciesIntegrationTest {
+
+    def "will configure dependencies"() {
+        given:
+        buildFile << """
+            dependencies {
+                implementation playDep.json()
+            }
+        """
+        when:
+        build("dependencies")
+        then:
+        true
+    }
+
+}

--- a/src/main/java/org/gradle/playframework/extensions/PlayDependencies.java
+++ b/src/main/java/org/gradle/playframework/extensions/PlayDependencies.java
@@ -1,0 +1,89 @@
+package org.gradle.playframework.extensions;
+
+import org.apache.groovy.util.Maps;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.ExternalModuleDependency;
+import org.gradle.api.provider.Provider;
+
+import javax.inject.Inject;
+
+public class PlayDependencies {
+    private final Project project;
+    private final PlayExtension playExtension;
+
+    @Inject
+    public PlayDependencies(Project project, PlayExtension playExtension) {
+        this.project = project;
+        this.playExtension = playExtension;
+    }
+
+    private static String extractMajorMinorVersion(String version) {
+        return String.join(".", version.split("\\.", 2));
+    }
+
+    private String lazyGetScalaMajorMinorVersion() {
+        return playExtension.getPlatform().getScalaVersion().map(PlayDependencies::extractMajorMinorVersion).get();
+    }
+
+    public Provider<ExternalModuleDependency> evolutions() {
+        return playComponent("play-jdbc-evolutions");
+    }
+
+    public Provider<ExternalModuleDependency> jdbc() {
+        return playComponent("play-jdbc");
+    }
+
+    public Provider<ExternalModuleDependency> javaCore() {
+        return playComponent("play-java");
+    }
+
+    public Provider<ExternalModuleDependency> javaJdbc() {
+        return playComponent("play-java-jdbc");
+    }
+
+    public Provider<ExternalModuleDependency> javaJpa() {
+        return playComponent("play-java-jpa");
+    }
+
+    public Provider<ExternalModuleDependency> filters() {
+        return playComponent("filters-helpers");
+    }
+
+    public Provider<ExternalModuleDependency> cache() {
+        return playComponent("play-cache");
+    }
+
+    public Provider<ExternalModuleDependency> json() {
+        return playComponent("play-json");
+    }
+
+    public Provider<ExternalModuleDependency> ws() {
+        return playComponent("play-ws");
+    }
+
+    public Provider<ExternalModuleDependency> javaWs() {
+        return playComponent("play-java-ws");
+    }
+
+    public Provider<ExternalModuleDependency> specs2() {
+        return playComponent("play-specs2");
+    }
+
+    public Provider<ExternalModuleDependency> playComponent(String id) {
+        return scalaVersionedInternal("com.typesafe.play", id, playExtension.getPlatform().getPlayVersion());
+    }
+
+    public Provider<ExternalModuleDependency> scalaVersioned(String group, String name, String version) {
+        return scalaVersionedInternal(group, name, project.provider(() -> version));
+    }
+
+    private Provider<ExternalModuleDependency> scalaVersionedInternal(String group, String name, Provider<String> version) {
+        return project.provider(() -> (ExternalModuleDependency) project.getDependencies().create(
+            Maps.of(
+                "group", group,
+                "name", name + "_" + lazyGetScalaMajorMinorVersion(),
+                "version", version
+            )
+        ));
+    }
+}

--- a/src/main/java/org/gradle/playframework/plugins/PlayApplicationPlugin.java
+++ b/src/main/java/org/gradle/playframework/plugins/PlayApplicationPlugin.java
@@ -52,8 +52,9 @@ public class PlayApplicationPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getPluginManager().apply(ScalaPlugin.class);
+        project.getPluginManager().apply(PlayConventionPlugin.class);
 
-        PlayExtension playExtension = project.getExtensions().create(PLAY_EXTENSION_NAME, PlayExtension.class, project.getObjects());
+        PlayExtension playExtension = (PlayExtension) project.getExtensions().getByName(PLAY_EXTENSION_NAME);
         Configuration playConfiguration = project.getConfigurations().create(PLATFORM_CONFIGURATION);
         project.getConfigurations().getByName(COMPILE_CLASSPATH_CONFIGURATION_NAME).extendsFrom(playConfiguration);
 

--- a/src/main/java/org/gradle/playframework/plugins/PlayConventionPlugin.java
+++ b/src/main/java/org/gradle/playframework/plugins/PlayConventionPlugin.java
@@ -1,0 +1,14 @@
+package org.gradle.playframework.plugins;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.playframework.extensions.PlayExtension;
+
+import static org.gradle.playframework.plugins.PlayApplicationPlugin.PLAY_EXTENSION_NAME;
+
+public class PlayConventionPlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        project.getExtensions().create(PLAY_EXTENSION_NAME, PlayExtension.class, project.getObjects());
+    }
+}

--- a/src/main/java/org/gradle/playframework/plugins/PlayDependenciesPlugin.java
+++ b/src/main/java/org/gradle/playframework/plugins/PlayDependenciesPlugin.java
@@ -1,0 +1,19 @@
+package org.gradle.playframework.plugins;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.playframework.extensions.PlayDependencies;
+import org.gradle.playframework.extensions.PlayExtension;
+
+/**
+ * Plugin for Play dependencies support.
+ */
+public class PlayDependenciesPlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        project.getPluginManager().apply(PlayConventionPlugin.class);
+
+        PlayExtension playExtension = (PlayExtension) project.getExtensions().getByName(PlayApplicationPlugin.PLAY_EXTENSION_NAME);
+        project.getDependencies().getExtensions().create("playDep", PlayDependencies.class, project, playExtension);
+    }
+}

--- a/src/main/java/org/gradle/playframework/plugins/PlayPlugin.java
+++ b/src/main/java/org/gradle/playframework/plugins/PlayPlugin.java
@@ -17,7 +17,9 @@ public class PlayPlugin implements Plugin<Project> {
     }
 
     private static void applyPlugins(Project project) {
+        project.getPluginManager().apply(PlayConventionPlugin.class);
         project.getPluginManager().apply(PlayApplicationPlugin.class);
+        project.getPluginManager().apply(PlayDependenciesPlugin.class);
         project.getPluginManager().apply(PlayJavaScriptPlugin.class);
         project.getPluginManager().apply(PlayDistributionPlugin.class);
         project.getPluginManager().apply(PlayIdePlugin.class);


### PR DESCRIPTION
Adds a plugin that simplifies declaring dependencies:

```
dependencies {
    implementation(playDep.json()) // Becomes: 'com.typesafe.play:play-json_2.11:2.4.2
}
// This is declared later, so we need to support providers
play {
    platform {
        playVersion.set("2.4.2")
        scalaVersion.set("2.11.6")
    }
}
```

---

Blocked by https://github.com/gradle/gradle/pull/11767

Currently, the `DependencyHandler` object doesn't support accepting `Provider` types.