### PR TITLE
Mark conf directory as resource root in IDEA

### DIFF
--- a/src/integTest/groovy/org/gradle/playframework/application/PlayIdeaPluginIntegrationTest.groovy
+++ b/src/integTest/groovy/org/gradle/playframework/application/PlayIdeaPluginIntegrationTest.groovy
@@ -47,6 +47,7 @@ abstract class PlayIdeaPluginIntegrationTest extends PlayIdePluginIntegrationTes
         then:
         def content = parseIml(moduleFile).content
         content.assertContainsSourcePaths(sourcePaths)
+        content.assertContainsResourcePaths("conf")
         content.assertContainsExcludes("build", ".gradle")
     }
 

--- a/src/integTestFixtures/groovy/org/gradle/playframework/fixtures/ide/IdeaModuleFixture.groovy
+++ b/src/integTestFixtures/groovy/org/gradle/playframework/fixtures/ide/IdeaModuleFixture.groovy
@@ -24,7 +24,7 @@ class IdeaModuleFixture extends IdeProjectFixture {
     IdeaContentRoot getContent() {
         def contentRoot = iml.component.content
         def sourceFolders = contentRoot.sourceFolder.collect {
-            new SourceFolder(url: it.@url, isTestSource: "true" == it.@isTestSource)
+            new SourceFolder(url: it.@url, type: it.@type, isTestSource: "true" == it.@isTestSource)
         }
         def excludeFolders = contentRoot.excludeFolder.collect {
             new ExcludeFolder(url: it.@url)
@@ -35,6 +35,7 @@ class IdeaModuleFixture extends IdeProjectFixture {
     @ToString
     class SourceFolder {
         String url
+        String type
         boolean isTestSource = false
     }
 
@@ -55,6 +56,16 @@ class IdeaModuleFixture extends IdeProjectFixture {
             } as Set
 
             def setDiff = CollectionUtils.diffSetsBy(sourceRoots, CollectionUtils.toSet(paths as List), Transformers.noOpTransformer())
+            assert setDiff.leftOnly.empty
+            assert setDiff.rightOnly.empty
+        }
+
+        void assertContainsResourcePaths(String... paths) {
+            def resourceRoots = sources.findAll { it.type == "java-resource" }.collect {
+                it.url - 'file://$MODULE_DIR$/'
+            } as Set
+
+            def setDiff = CollectionUtils.diffSetsBy(resourceRoots, CollectionUtils.toSet(paths as List), Transformers.noOpTransformer())
             assert setDiff.leftOnly.empty
             assert setDiff.rightOnly.empty
         }

--- a/src/main/java/org/gradle/playframework/plugins/PlayIdeaPlugin.java
+++ b/src/main/java/org/gradle/playframework/plugins/PlayIdeaPlugin.java
@@ -1,5 +1,8 @@
 package org.gradle.playframework.plugins;
 
+import groovy.util.Node;
+import groovy.util.NodeList;
+import groovy.xml.QName;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -67,6 +70,16 @@ public class PlayIdeaPlugin implements Plugin<Project> {
 
             conventionMapping.map("targetBytecodeVersion", (Callable<JavaVersion>) () -> getTargetJavaVersion(playExtension.getPlatform()));
             conventionMapping.map("languageLevel", (Callable<IdeaLanguageLevel>) () -> new IdeaLanguageLevel(getTargetJavaVersion(playExtension.getPlatform())));
+
+            module.getIml().withXml(xml -> {
+                NodeList sourceFolders = xml.asNode().getAt(QName.valueOf("component")).getAt(QName.valueOf("content")).getAt(QName.valueOf("sourceFolder"));
+                sourceFolders.forEach(sourceFolder -> {
+                    Node node = (Node) sourceFolder;
+                    if (node.get("@url").equals("file://$MODULE_DIR$/conf")) {
+                        node.attributes().put("type", "java-resource");
+                    }
+                });
+            });
 
             ideaModuleTask.dependsOn(classesTask);
             ideaModuleTask.dependsOn(javaScriptMinifyTask);


### PR DESCRIPTION
The `conf` directory is not just a source root, it should be also a resource root as well (similar to `src/main/resources` in usual Java project layout).

After applying this change, it is correctly recognized as resource in IDEA:

![Screen Shot 2020-03-07 at 20 17 03](https://user-images.githubusercontent.com/1525580/76144229-b8d99800-60b0-11ea-863c-437a0525c7bd.png)
