### PR TITLE
Implement support for WebJars and LESS as assets pipeline

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,20 @@ gradlePlugin {
             implementationClass = "org.gradle.playframework.plugins.PlayRoutesPlugin"
         }
 
+        register("play-less-plugin") {
+            id = "org.gradle.playframework-less"
+            displayName = "Play LESS Plugin"
+            description = "Plugin for compiling LESS stylesheets in a Play application."
+            implementationClass = "org.gradle.playframework.plugins.PlayLessPlugin"
+        }
+
+        register("play-webjars-plugin") {
+            id = "org.gradle.playframework-webjars"
+            displayName = "Play WebJars Plugin"
+            description = "Plugin for extracting WebJars in a Play application."
+            implementationClass = "org.gradle.playframework.plugins.PlayWebJarsPlugin"
+        }
+
         register("play-application-plugin") {
             id = "org.gradle.playframework-application"
             displayName = "Play Application Plugin"

--- a/buildSrc/src/main/kotlin/org/gradle/playframework/UserGuidePlugin.kt
+++ b/buildSrc/src/main/kotlin/org/gradle/playframework/UserGuidePlugin.kt
@@ -57,6 +57,8 @@ class UserGuidePlugin : Plugin<Project> {
                     val htmlUserGuideFile = file("$outputDir/html5/index.html")
                     var text = htmlUserGuideFile.readText()
                     text = text.replace(Regex("id 'org.gradle.playframework' version '.+'"), "id 'org.gradle.playframework' version '${project.version}'")
+                    text = text.replace(Regex("id 'org.gradle.playframework-less' version '.+'"), "id 'org.gradle.playframework-less' version '${project.version}'")
+                    text = text.replace(Regex("id 'org.gradle.playframework-webjars' version '.+'"), "id 'org.gradle.playframework-webjars' version '${project.version}'")
                     htmlUserGuideFile.writeText(text)
                 }
             }

--- a/src/docs/asciidoc/13-tasks.adoc
+++ b/src/docs/asciidoc/13-tasks.adoc
@@ -14,6 +14,10 @@ _Depends on_: `stageMainDist`
 +
 Stages the Play distribution.
 
+`createPlayAssetsJar` — {uri-gradle-dsl-reference}/org.gradle.api.Task.html[Task]::
++
+Bundles asset files into a jar file.
+
 ==== Running and testing tasks
 
 The plugin also provides tasks for running, testing and packaging your Play application.

--- a/src/docs/asciidoc/14-source-sets.adoc
+++ b/src/docs/asciidoc/14-source-sets.adoc
@@ -5,32 +5,43 @@ One type of element that describes the application are the source sets that defi
 .Default Play source sets
 [%header%autowidth,compact]
 |===
-| Source Set | Type | Directory | Filters
+| Source Set | Type | Directory | Filters | Plugin extension
 
 | java
 | {uri-gradle-dsl-reference}/org.gradle.api.tasks.SourceSet.html[SourceSet]
 | app
 | \**/*.java
+| (built-in)
 
 | scala
 | {uri-gradle-dsl-reference}/org.gradle.api.tasks.SourceSet.html[SourceSet]
 | app
 | \**/*.scala
+| (built-in)
 
 | routes
 | link:{uri-plugin-api}/org/gradle/playframework/sourcesets/RoutesSourceSet.html[RoutesSourceSet]
 | conf
 | routes, *.routes
+| (built-in)
 
 | twirl
 | link:{uri-plugin-api}/org/gradle/playframework/sourcesets/TwirlSourceSet.html[TwirlSourceSet]
 | app
 | \**/*.scala.*
+| (built-in)
 
 | javaScript
 | link:{uri-plugin-api}/org/gradle/playframework/sourcesets/JavaScriptSourceSet.html[JavaScriptSourceSet]
 | app/assets
 | \**/*.js
+| (built-in)
+
+| less
+| link:{uri-plugin-api}/org/gradle/playframework/sourcesets/LessSourceSet.html[LessSourceSet]
+| app/assets
+| \**/*.less
+| org.gradle.playframework-less
 |===
 
 These <<adding-source-directories,source sets can be configured>>.

--- a/src/docs/asciidoc/20-usage.adoc
+++ b/src/docs/asciidoc/20-usage.adoc
@@ -9,3 +9,5 @@ include::23-package-distribution.adoc[]
 include::24-multi-project.adoc[]
 
 include::25-ide.adoc[]
+
+include::26-asset-pipelines.adoc[]

--- a/src/docs/asciidoc/26-asset-pipelines.adoc
+++ b/src/docs/asciidoc/26-asset-pipelines.adoc
@@ -1,0 +1,67 @@
+=== Adding asset pipelines
+
+The Play plugin's `createPlayAssetsJar` task (on which `runPlay` and `dist` tasks depend) bundles all assets into a single jar file. This jar file is included in the distribution package to be served by the Play application.
+
+The following asset pipelines are supported.
+
+==== Public assets
+
+Files in the `public/` directory will be included in the assets JAR without any processing.
+
+==== JavaScript minification
+
+Files in the `javaScript` source set (the default one is `app/assets` with `\**/*.js` filter), will be minified using Google Closure compiler and then included in the assets jar.
+
+==== WebJars
+
+WebJar libraries will be extracted and then included in the assets jar, under the `lib/` subdirectory.
+
+To apply this pipeline, apply the `org.gradle.playframework-webjars` plugin as well:
+
+[source,groovy]
+.build.gradle
+----
+plugins {
+    id 'org.gradle.playframework' version '0.10'
+    id 'org.gradle.playframework-webjars' version '0.10'
+}
+----
+
+To add a WebJar library, add it to the dependency list using `webJar` configuration, e.g.:
+
+[source,groovy]
+.build.gradle
+----
+dependencies {
+    webJar 'org.webjars:requirejs:2.3.6'
+}
+----
+
+==== LESS compilation
+
+Files in the `less` source set (the default one is `app/assets` with `\**/*.less` filter) will be compiled into CSS and then included in the assets jar.
+
+To apply this pipeline, apply the `org.gradle.playframework-less` plugin as well:
+
+[source,groovy]
+.build.gradle
+----
+plugins {
+    id 'org.gradle.playframework' version '0.10'
+    id 'org.gradle.playframework-less' version '0.10'
+}
+----
+
+The following `\@import`s in LESS files are supported:
+
+- Partial LESS files (ones with start with underscores, such ass `_common.less`).
+- WebJar extracted files (using the WebJar pipeline described above), with `lib/` subdirectory prefix.
+
+Example:
+
+[source,less]
+.main.css
+----
+@import "./_common.less";
+@import "lib/css-reset/reset.css";
+----

--- a/src/docs/asciidoc/40-migrating-software-model.adoc
+++ b/src/docs/asciidoc/40-migrating-software-model.adoc
@@ -7,6 +7,5 @@ The following features are not available in this plugin:
 * The custom configurations `playTest` and `playRun` do not exist anymore. Use the standard configurations `implementation`, `testImplementation` and `runtime` of the Java/Scala plugin instead.
 * The extension does not allow for configuring a target platform. You will need to configure Play, Scala and Java version individually.
 * {uri-gradle-userguide}//play_plugin.html#sec:adding_extra_source_sets[Adding new source sets] of a specific type is a built-in feature of the software model. This functionality is currently not available.
-* The concept of an "asset" does not exist and therefore cannot be used to {uri-gradle-userguide}/play_plugin.html#sec:injecting_a_custom_asset_pipeline[configure a custom asset pipeline].
 * Source sets cannot be added by type. You will need to add additional source directories to the existing source sets provided by the plugin.
 * The CoffeeScript plugin is not available anymore.

--- a/src/docs/samples/source-sets/groovy/build.gradle
+++ b/src/docs/samples/source-sets/groovy/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'org.gradle.playframework' version '0.10'
+    id 'org.gradle.playframework-less' version '0.10'
 }
 
 repositories {
@@ -29,6 +30,10 @@ sourceSets {
         javaScript {
             srcDir 'additional/javascript'
             exclude '**/old_*.js'
+        }
+        less {
+            srcDir 'additional/less'
+            exclude '**/old_*.less'
         }
     }
 }

--- a/src/integTest/groovy/org/gradle/playframework/application/advanced/PlayBinaryAdvancedAppIntegrationTest.groovy
+++ b/src/integTest/groovy/org/gradle/playframework/application/advanced/PlayBinaryAdvancedAppIntegrationTest.groovy
@@ -4,11 +4,7 @@ import org.gradle.playframework.application.PlayApplicationPluginIntegrationTest
 import org.gradle.playframework.fixtures.app.AdvancedPlayApp
 import org.gradle.playframework.fixtures.app.PlayApp
 
-import static org.gradle.playframework.plugins.PlayTwirlPlugin.TWIRL_COMPILE_TASK_NAME
-
 class PlayBinaryAdvancedAppIntegrationTest extends PlayApplicationPluginIntegrationTest {
-
-    private static final TWIRL_COMPILE_TASK_PATH = ":$TWIRL_COMPILE_TASK_NAME".toString()
 
     @Override
     PlayApp getPlayApp() {
@@ -32,12 +28,10 @@ class PlayBinaryAdvancedAppIntegrationTest extends PlayApplicationPluginIntegrat
 
         jar("build/libs/${playApp.name}-assets.jar").containsDescendants(
                 "public/javascripts/sample.js",
-                "public/javascripts/sample.min.js"
+                "public/javascripts/sample.min.js",
+                "public/stylesheets/main.css",
+                "public/stylesheets/extra.css",
+                "public/lib/css-reset/reset.css",
         )
-    }
-
-    @Override
-    String[] getBuildTasks() {
-        return super.getBuildTasks() + TWIRL_COMPILE_TASK_PATH
     }
 }

--- a/src/integTest/groovy/org/gradle/playframework/plugins/PlayLessPluginIntegrationTest.groovy
+++ b/src/integTest/groovy/org/gradle/playframework/plugins/PlayLessPluginIntegrationTest.groovy
@@ -1,0 +1,77 @@
+package org.gradle.playframework.plugins
+
+import org.gradle.playframework.AbstractIntegrationTest
+
+import static org.gradle.playframework.fixtures.file.FileFixtures.findFile
+import static org.gradle.playframework.fixtures.Repositories.playRepositories
+import static org.gradle.playframework.plugins.PlayLessPlugin.LESS_COMPILE_TASK_NAME
+
+class PlayLessPluginIntegrationTest extends AbstractIntegrationTest {
+
+    def setup() {
+        buildFile << """
+            plugins {
+                id 'org.gradle.playframework'
+                id 'org.gradle.playframework-less'
+            }
+            
+            ${playRepositories()}
+        """
+    }
+
+    def "can compile LESS files"() {
+        given:
+        File lessDir = temporaryFolder.newFolder('app', 'assets', 'stylesheets')
+        new File(lessDir, 'main.less') << lessSource()
+
+        when:
+        build(LESS_COMPILE_TASK_NAME)
+
+        then:
+        File outputDir = file('build/src/play/less')
+        outputDir.isDirectory()
+
+        File[] cssFiles = new File(outputDir, 'stylesheets').listFiles()
+        cssFiles.length == 1
+        findFile(cssFiles, 'main.css')
+    }
+
+    def "can add source directories to default source set"() {
+        given:
+        File lessDir = temporaryFolder.newFolder('app', 'assets', 'stylesheets')
+        new File(lessDir, 'main.less') << lessSource()
+
+        File extraLessDir = temporaryFolder.newFolder('extra', 'less', 'stylesheets')
+        new File(extraLessDir, 'extra.less') << lessSource()
+
+        buildFile << """
+            sourceSets {
+                main {
+                    less {
+                        srcDir 'extra/less'
+                    }
+                }
+            }
+        """
+
+        when:
+        build(LESS_COMPILE_TASK_NAME)
+
+        then:
+        File outputDir = file('build/src/play/less')
+        outputDir.isDirectory()
+
+        File[] cssFiles = new File(outputDir, 'stylesheets').listFiles()
+        cssFiles.length == 2
+        findFile(cssFiles, 'main.css')
+        findFile(cssFiles, 'extra.css')
+    }
+
+    static String lessSource() {
+        """
+            .some-class {
+                float: left;
+            }
+        """
+    }
+}

--- a/src/integTest/groovy/org/gradle/playframework/plugins/PlayLessWithWebJarsPluginIntegrationTest.groovy
+++ b/src/integTest/groovy/org/gradle/playframework/plugins/PlayLessWithWebJarsPluginIntegrationTest.groovy
@@ -1,0 +1,53 @@
+package org.gradle.playframework.plugins
+
+import org.gradle.playframework.AbstractIntegrationTest
+
+import static org.gradle.playframework.fixtures.Repositories.playRepositories
+import static org.gradle.playframework.fixtures.file.FileFixtures.findFile
+import static org.gradle.playframework.plugins.PlayLessPlugin.LESS_COMPILE_TASK_NAME
+
+class PlayLessWithWebJarsPluginIntegrationTest extends AbstractIntegrationTest {
+
+    def setup() {
+        buildFile << """
+            plugins {
+                id 'org.gradle.playframework'
+                id 'org.gradle.playframework-less'
+                id 'org.gradle.playframework-webjars'
+            }
+            
+            ${playRepositories()}
+
+            dependencies {
+                webJar 'org.webjars.bower:css-reset:2.5.1'
+            }
+        """
+    }
+
+    def "can compile LESS files which import files in WebJars"() {
+        given:
+        File lessDir = temporaryFolder.newFolder('app', 'assets', 'stylesheets')
+        new File(lessDir, 'main.less') << lessSource()
+
+        when:
+        build(LESS_COMPILE_TASK_NAME)
+
+        then:
+        File outputDir = file('build/src/play/less')
+        outputDir.isDirectory()
+
+        File[] cssFiles = new File(outputDir, 'stylesheets').listFiles()
+        cssFiles.length == 1
+        findFile(cssFiles, 'main.css')
+    }
+
+    static String lessSource() {
+        """
+            @import (inline) "lib/css-reset/reset.css";
+
+            .some-class {
+                float: left;
+            }
+        """
+    }
+}

--- a/src/integTest/groovy/org/gradle/playframework/plugins/PlayWebJarsPluginIntegrationTest.groovy
+++ b/src/integTest/groovy/org/gradle/playframework/plugins/PlayWebJarsPluginIntegrationTest.groovy
@@ -1,0 +1,40 @@
+package org.gradle.playframework.plugins
+
+import org.gradle.playframework.AbstractIntegrationTest
+
+import static org.gradle.playframework.fixtures.Repositories.playRepositories
+import static org.gradle.playframework.fixtures.file.FileFixtures.findFile
+import static org.gradle.playframework.plugins.PlayWebJarsPlugin.WEBJARS_EXTRACT_TASK_NAME
+
+class PlayWebJarsPluginIntegrationTest extends AbstractIntegrationTest {
+
+    def setup() {
+        buildFile << """
+            plugins {
+                id 'org.gradle.playframework'
+                id 'org.gradle.playframework-webjars'
+            }
+            
+            ${playRepositories()}
+            
+            dependencies {
+                webJar 'org.webjars:requirejs:2.3.6'
+                webJar 'org.webjars.npm:inherits:2.0.4'
+            }
+        """
+    }
+
+    def "can extract WebJars"() {
+        when:
+        build(WEBJARS_EXTRACT_TASK_NAME)
+
+        then:
+        File outputDir = file('build/src/play/webJars/lib')
+        outputDir.isDirectory()
+
+        File[] libs = outputDir.listFiles()
+        libs.length == 2
+        findFile(libs, 'requirejs')
+        findFile(libs, 'inherits')
+    }
+}

--- a/src/integTest/groovy/org/gradle/playframework/tasks/AbstractAssetsTaskIntegrationTest.groovy
+++ b/src/integTest/groovy/org/gradle/playframework/tasks/AbstractAssetsTaskIntegrationTest.groovy
@@ -1,0 +1,34 @@
+package org.gradle.playframework.tasks
+
+import org.gradle.playframework.AbstractIntegrationTest
+import org.gradle.playframework.fixtures.archive.JarTestFixture
+
+import static org.gradle.api.plugins.JavaPlugin.JAR_TASK_NAME
+import static org.gradle.playframework.plugins.PlayApplicationPlugin.ASSETS_JAR_TASK_NAME
+
+abstract class AbstractAssetsTaskIntegrationTest extends AbstractIntegrationTest {
+    static final JAR_TASK_PATH = ":$JAR_TASK_NAME".toString()
+    static final ASSETS_JAR_TASK_PATH = ":$ASSETS_JAR_TASK_NAME".toString()
+
+    JarTestFixture jar(String fileName) {
+        new JarTestFixture(file(fileName))
+    }
+
+    File assets(String fileName) {
+        File assetsDir = file('app/assets')
+
+        if (!assetsDir.isDirectory()) {
+            temporaryFolder.newFolder('app', 'assets')
+        }
+
+        new File(assetsDir, fileName)
+    }
+
+    boolean compareWithoutWhiteSpace(String string1, String string2) {
+        return withoutWhiteSpace(string1) == withoutWhiteSpace(string2)
+    }
+
+    def withoutWhiteSpace(String string) {
+        return string.replaceAll("\\s+", " ");
+    }
+}

--- a/src/integTest/groovy/org/gradle/playframework/tasks/AbstractJavaScriptMinifyIntegrationTest.groovy
+++ b/src/integTest/groovy/org/gradle/playframework/tasks/AbstractJavaScriptMinifyIntegrationTest.groovy
@@ -1,10 +1,9 @@
 package org.gradle.playframework.tasks
 
-import org.gradle.playframework.AbstractIntegrationTest
 import org.gradle.playframework.fixtures.archive.JarTestFixture
 import org.gradle.util.TextUtil
 
-abstract class AbstractJavaScriptMinifyIntegrationTest extends AbstractIntegrationTest {
+abstract class AbstractJavaScriptMinifyIntegrationTest extends AbstractAssetsTaskIntegrationTest {
 
     def setup() {
         settingsFile << """ rootProject.name = 'js-play-app' """
@@ -14,20 +13,6 @@ abstract class AbstractJavaScriptMinifyIntegrationTest extends AbstractIntegrati
 
     JarTestFixture getAssetsJar() {
         jar("build/libs/js-play-app-assets.jar")
-    }
-
-    JarTestFixture jar(String fileName) {
-        new JarTestFixture(file(fileName))
-    }
-
-    File assets(String fileName) {
-        File assetsDir = file('app/assets')
-
-        if (!assetsDir.isDirectory()) {
-            temporaryFolder.newFolder('app', 'assets')
-        }
-
-        new File(assetsDir, fileName)
     }
 
     File processedJavaScript(String fileName) {
@@ -42,14 +27,6 @@ abstract class AbstractJavaScriptMinifyIntegrationTest extends AbstractIntegrati
     void hasExpectedJavaScript(File file) {
         assert file.exists()
         assert compareWithoutWhiteSpace(file.text, expectedJavaScript())
-    }
-
-    boolean compareWithoutWhiteSpace(String string1, String string2) {
-        return withoutWhiteSpace(string1) == withoutWhiteSpace(string2)
-    }
-
-    def withoutWhiteSpace(String string) {
-        return string.replaceAll("\\s+", " ");
     }
 
     def withJavaScriptSource(String path) {

--- a/src/integTest/groovy/org/gradle/playframework/tasks/JavaScriptMinifyIntegrationTest.groovy
+++ b/src/integTest/groovy/org/gradle/playframework/tasks/JavaScriptMinifyIntegrationTest.groovy
@@ -4,15 +4,11 @@ import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 
 import static org.gradle.playframework.fixtures.Repositories.playRepositories
-import static org.gradle.playframework.plugins.PlayApplicationPlugin.ASSETS_JAR_TASK_NAME
 import static org.gradle.playframework.plugins.PlayJavaScriptPlugin.JS_MINIFY_TASK_NAME
-import static org.gradle.api.plugins.JavaPlugin.JAR_TASK_NAME
 
 class JavaScriptMinifyIntegrationTest extends AbstractJavaScriptMinifyIntegrationTest {
 
     private static final JS_MINIFY_TASK_PATH = ":$JS_MINIFY_TASK_NAME".toString()
-    private static final JAR_TASK_PATH = ":$JAR_TASK_NAME".toString()
-    private static final ASSETS_JAR_TASK_PATH = ":$ASSETS_JAR_TASK_NAME".toString()
 
     File getProcessedJavaScriptDir() {
         file("build/src/play/javaScript")

--- a/src/integTest/groovy/org/gradle/playframework/tasks/LessCompileIntegrationTest.groovy
+++ b/src/integTest/groovy/org/gradle/playframework/tasks/LessCompileIntegrationTest.groovy
@@ -1,0 +1,188 @@
+package org.gradle.playframework.tasks
+
+import org.gradle.playframework.fixtures.archive.JarTestFixture
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.TaskOutcome
+
+import static org.gradle.playframework.fixtures.Repositories.playRepositories
+import static org.gradle.playframework.plugins.PlayLessPlugin.LESS_COMPILE_TASK_NAME
+
+class LessCompileIntegrationTest extends AbstractAssetsTaskIntegrationTest {
+    private static final LESS_COMPILE_TASK_PATH = ":$LESS_COMPILE_TASK_NAME".toString()
+
+    def setup() {
+        settingsFile << """ rootProject.name = 'less-play-app' """
+
+        buildFile << """
+            plugins {
+                id 'org.gradle.playframework'
+                id 'org.gradle.playframework-less'
+            }
+
+            ${playRepositories()}
+        """
+    }
+
+    def "compiles default less source set as part of Play application build"() {
+        given:
+        withMainLessSource(assets("main.less"))
+        withLessSource(assets("_partial.less"))
+
+        when:
+        BuildResult result = build "assemble"
+
+        then:
+        result.task(LESS_COMPILE_TASK_PATH).outcome == TaskOutcome.SUCCESS
+        result.task(JAR_TASK_PATH).outcome == TaskOutcome.SUCCESS
+        result.task(ASSETS_JAR_TASK_PATH).outcome == TaskOutcome.SUCCESS
+        assetsJar.containsDescendants(
+                "public/main.css"
+        )
+
+        and:
+        hasProcessedMainCss("main")
+    }
+
+    def "does not recompile when inputs and outputs are unchanged"() {
+        given:
+        withMainLessSource(assets("main.less"))
+        withLessSource(assets("_partial.less"))
+        build "assemble"
+
+        when:
+        BuildResult result = build "assemble"
+
+        then:
+        result.task(LESS_COMPILE_TASK_PATH).outcome == TaskOutcome.UP_TO_DATE
+        result.task(JAR_TASK_PATH).outcome == TaskOutcome.UP_TO_DATE
+        result.task(ASSETS_JAR_TASK_PATH).outcome == TaskOutcome.UP_TO_DATE
+    }
+
+    def "recompiles when an output is removed" () {
+        given:
+        withMainLessSource(assets("main.less"))
+        withLessSource(assets("_partial.less"))
+        build "assemble"
+
+        when:
+        processedCss("main").delete()
+        assetsJar.file.delete()
+        BuildResult result = build "assemble"
+
+        then:
+        result.task(LESS_COMPILE_TASK_PATH).outcome == TaskOutcome.SUCCESS
+        result.task(ASSETS_JAR_TASK_PATH).outcome == TaskOutcome.SUCCESS
+        hasProcessedMainCss("main")
+    }
+
+    def "recompiles when an input is changed" () {
+        given:
+        withMainLessSource(assets("main.less"))
+        withLessSource(assets("_partial.less"))
+        build "assemble"
+
+        when:
+        file("app/assets/main.less") << ".other-class { margin: auto; }"
+        BuildResult result = build "assemble"
+
+        then:
+        result.task(LESS_COMPILE_TASK_PATH).outcome == TaskOutcome.SUCCESS
+        result.task(ASSETS_JAR_TASK_PATH).outcome == TaskOutcome.SUCCESS
+    }
+
+    def "cleans removed source file on compile" () {
+        given:
+        withMainLessSource(assets("main.less"))
+        withLessSource(assets("_partial.less"))
+        def source2 = withLessSource(assets("extra.less"))
+
+        when:
+        build "assemble"
+
+        then:
+        hasProcessedMainCss("main")
+        hasProcessedCss("extra")
+        assetsJar.containsDescendants(
+                "public/main.css",
+                "public/extra.css",
+        )
+
+        when:
+        source2.delete()
+        build "assemble"
+
+        then:
+        ! processedCss("extra").exists()
+        assetsJar.countFiles("public/extra.css") == 0
+    }
+
+    def "produces sensible error on compile failure"() {
+        given:
+        assets("main.less") << "BAD SOURCE"
+
+        when:
+        BuildResult result = buildAndFail "assemble"
+
+        then:
+        result.output.contains("Execution failed for task ':compilePlayLess'.")
+        result.output.contains("Could not compile less.")
+        String slash = File.separator
+        result.output.contains("app${slash}assets${slash}main.less 1:11")
+    }
+
+    def withMainLessSource(File file) {
+        file << """
+            @import _partial;
+            
+            .class1 {
+                float: left;
+                
+                .class2 {
+                    float: right;
+                }
+            }
+        """
+    }
+
+    def withLessSource(File file) {
+        file << """
+            .class3 {
+                margin: auto;
+            }
+        """
+    }
+
+    JarTestFixture getAssetsJar() {
+        jar("build/libs/less-play-app-assets.jar")
+    }
+
+    File processedCss(String fileName) {
+        new File(file("build/src/play/less"), "${fileName}.css")
+    }
+
+    void hasProcessedMainCss(String fileName) {
+        hasExpectedMainCss(processedCss(fileName))
+    }
+
+    void hasProcessedCss(String fileName) {
+        hasExpectedCss(processedCss(fileName))
+    }
+
+    void hasExpectedMainCss(File file) {
+        assert file.exists()
+        assert compareWithoutWhiteSpace(file.text.readLines().get(0), expectedMainCss())
+    }
+
+    void hasExpectedCss(File file) {
+        assert file.exists()
+        assert compareWithoutWhiteSpace(file.text.readLines().get(0), expectedCss())
+    }
+
+    String expectedMainCss() {
+        """.class3{margin:auto;} .class1{float:left;} .class1 .class2{float:right;}"""
+    }
+
+    String expectedCss() {
+        """.class3{margin:auto;}"""
+    }
+}

--- a/src/integTest/groovy/org/gradle/playframework/tasks/WebJarsExtractIntegrationTest.groovy
+++ b/src/integTest/groovy/org/gradle/playframework/tasks/WebJarsExtractIntegrationTest.groovy
@@ -1,0 +1,77 @@
+package org.gradle.playframework.tasks
+
+import org.gradle.playframework.fixtures.archive.JarTestFixture
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.TaskOutcome
+
+import static org.gradle.playframework.fixtures.Repositories.playRepositories
+import static org.gradle.playframework.plugins.PlayWebJarsPlugin.WEBJARS_EXTRACT_TASK_NAME
+
+class WebJarsExtractIntegrationTest extends AbstractAssetsTaskIntegrationTest {
+    private static final WEBJARS_EXTRACT_TASK_PATH = ":$WEBJARS_EXTRACT_TASK_NAME".toString()
+
+    def setup() {
+        settingsFile << """ rootProject.name = 'webjars-play-app' """
+
+        buildFile << """
+            plugins {
+                id 'org.gradle.playframework'
+                id 'org.gradle.playframework-webjars'
+            }
+
+            ${playRepositories()}
+
+            dependencies {
+                webJar 'org.webjars.bower:css-reset:2.5.1'
+            }
+        """
+    }
+
+    def "extracts WebJars as part of Play application build"() {
+        when:
+        BuildResult result = build "assemble"
+
+        then:
+        result.task(WEBJARS_EXTRACT_TASK_PATH).outcome == TaskOutcome.SUCCESS
+        result.task(JAR_TASK_PATH).outcome == TaskOutcome.SUCCESS
+        result.task(ASSETS_JAR_TASK_PATH).outcome == TaskOutcome.SUCCESS
+        assetsJar.containsDescendants(
+                "public/lib/css-reset/reset.css"
+        )
+    }
+
+    def "does not reextract when outputs are unchanged"() {
+        given:
+        build "assemble"
+
+        when:
+        BuildResult result = build "assemble"
+
+        then:
+        result.task(WEBJARS_EXTRACT_TASK_PATH).outcome == TaskOutcome.UP_TO_DATE
+        result.task(JAR_TASK_PATH).outcome == TaskOutcome.UP_TO_DATE
+        result.task(ASSETS_JAR_TASK_PATH).outcome == TaskOutcome.UP_TO_DATE
+    }
+
+    def "reextracts when an output is removed" () {
+        given:
+        build "assemble"
+
+        when:
+        extractedWebJar("lib/css-reset/reset.css").delete()
+        assetsJar.file.delete()
+        BuildResult result = build "assemble"
+
+        then:
+        result.task(WEBJARS_EXTRACT_TASK_PATH).outcome == TaskOutcome.SUCCESS
+        result.task(ASSETS_JAR_TASK_PATH).outcome == TaskOutcome.SUCCESS
+    }
+
+    JarTestFixture getAssetsJar() {
+        jar("build/libs/webjars-play-app-assets.jar")
+    }
+
+    File extractedWebJar(String fileName) {
+        new File(file("build/src/play/webJars"), fileName)
+    }
+}

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/advancedplayapp/app/assets/stylesheets/extra.less
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/advancedplayapp/app/assets/stylesheets/extra.less
@@ -1,0 +1,3 @@
+.extra {
+    padding-top: 10px;
+}

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/advancedplayapp/app/views/main.scala.html
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/advancedplayapp/app/views/main.scala.html
@@ -4,6 +4,7 @@
 <head>
     <title>@title</title>
     @**<link rel="stylesheet" media="screen" href="@routes.Assets.at("stylesheets/main.css")">
+    @**<link rel="stylesheet" media="screen" href="@routes.Assets.at("stylesheets/extra.css")">
     <link rel="shortcut icon" type="image/svg" href="@routes.Assets.at("images/favicon.svg")">
     <script src="@routes.Assets.at("javascripts/hello.js")" type="text/javascript"></script>**@
 </head>

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/advancedplayapp/build.gradle.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/advancedplayapp/build.gradle.ftl
@@ -1,5 +1,7 @@
 plugins {
     id 'org.gradle.playframework'
+    id 'org.gradle.playframework-less'
+    id 'org.gradle.playframework-webjars'
 }
 
 // repositories added in PlayApp class
@@ -12,6 +14,10 @@ sourceSets {
             include "jva/**/*"
         }
     }
+}
+
+dependencies {
+    webJar 'org.webjars.bower:css-reset:2.5.1'
 }
 
 <#if playVersion == "2.7" || playVersion == "2.6">

--- a/src/main/java/org/gradle/playframework/plugins/PlayApplicationPlugin.java
+++ b/src/main/java/org/gradle/playframework/plugins/PlayApplicationPlugin.java
@@ -49,6 +49,7 @@ public class PlayApplicationPlugin implements Plugin<Project> {
 
     static final String PLAY_EXTENSION_NAME = "play";
     static final String PLATFORM_CONFIGURATION = "play";
+    public static final String PLAY_RUN_TASK_NAME = "runPlay";
     public static final String ASSETS_JAR_TASK_NAME = "createPlayAssetsJar";
 
     @Override
@@ -155,7 +156,7 @@ public class PlayApplicationPlugin implements Plugin<Project> {
     }
 
     private TaskProvider<PlayRun> createRunTask(Project project, PlayExtension playExtension, TaskProvider<Jar> mainJarTask, TaskProvider<Jar> assetsJarTask) {
-        return project.getTasks().register("runPlay", PlayRun.class, playRun -> {
+        return project.getTasks().register(PLAY_RUN_TASK_NAME, PlayRun.class, playRun -> {
             playRun.setDescription("Runs the Play application for local development.");
             playRun.setGroup("Run");
             playRun.getWorkingDir().convention(project.getLayout().getProjectDirectory());

--- a/src/main/java/org/gradle/playframework/plugins/PlayJavaScriptPlugin.java
+++ b/src/main/java/org/gradle/playframework/plugins/PlayJavaScriptPlugin.java
@@ -1,13 +1,17 @@
 package org.gradle.playframework.plugins;
 
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.playframework.plugins.internal.PlayPluginHelper;
 import org.gradle.playframework.sourcesets.JavaScriptSourceSet;
 import org.gradle.playframework.sourcesets.internal.DefaultJavaScriptSourceSet;
 import org.gradle.playframework.tasks.JavaScriptMinify;
+import org.gradle.playframework.tasks.PlayRun;
 import org.gradle.playframework.tools.internal.javascript.GoogleClosureCompiler;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.SourceDirectorySet;
+
+import static org.gradle.playframework.plugins.PlayApplicationPlugin.PLAY_RUN_TASK_NAME;
 
 /**
  * Plugin for adding javascript processing to a Play application.
@@ -38,12 +42,15 @@ public class PlayJavaScriptPlugin implements PlayGeneratedSourcePlugin {
     }
 
     private void createDefaultJavaScriptMinifyTask(Project project, SourceDirectorySet sourceDirectory, Configuration compilerConfiguration) {
-        project.getTasks().register(JS_MINIFY_TASK_NAME, JavaScriptMinify.class, javaScriptMinify -> {
+        TaskProvider<JavaScriptMinify> javaScriptMinifyTask = project.getTasks().register(JS_MINIFY_TASK_NAME, JavaScriptMinify.class, javaScriptMinify -> {
             javaScriptMinify.setDescription("Minifies javascript for the " + sourceDirectory.getDisplayName() + ".");
             javaScriptMinify.getDestinationDir().set(getOutputDir(project, sourceDirectory));
             javaScriptMinify.setSource(sourceDirectory);
             javaScriptMinify.getCompilerClasspath().setFrom(compilerConfiguration);
             javaScriptMinify.dependsOn(sourceDirectory);
+        });
+        project.getTasks().named(PLAY_RUN_TASK_NAME, PlayRun.class, task -> {
+            task.getAssetsDirs().from(javaScriptMinifyTask.get().getDestinationDir());
         });
     }
 }

--- a/src/main/java/org/gradle/playframework/plugins/PlayLessPlugin.java
+++ b/src/main/java/org/gradle/playframework/plugins/PlayLessPlugin.java
@@ -1,0 +1,72 @@
+package org.gradle.playframework.plugins;
+
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.file.SourceDirectorySet;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.bundling.Jar;
+import org.gradle.playframework.sourcesets.LessSourceSet;
+import org.gradle.playframework.sourcesets.internal.DefaultLessSourceSet;
+import org.gradle.playframework.tasks.LessCompile;
+import org.gradle.playframework.tasks.PlayRun;
+import org.gradle.playframework.tools.internal.less.Less4jCompiler;
+
+import static org.gradle.api.plugins.BasePlugin.ASSEMBLE_TASK_NAME;
+import static org.gradle.playframework.plugins.PlayApplicationPlugin.ASSETS_JAR_TASK_NAME;
+import static org.gradle.playframework.plugins.PlayApplicationPlugin.PLAY_RUN_TASK_NAME;
+import static org.gradle.playframework.plugins.internal.PlayPluginHelper.createCustomSourceSet;
+
+/**
+ * Plugin for compiling LESS stylesheets into CSS stylesheets in a Play application.
+ */
+public class PlayLessPlugin implements PlayGeneratedSourcePlugin {
+    public static final String LESS_COMPILER_CONFIGURATION_NAME = "lessCompiler";
+    public static final String LESS_COMPILE_TASK_NAME = "compilePlayLess";
+
+    @Override
+    public void apply(Project project) {
+        Configuration configuration = createLessCompilerConfiguration(project);
+        declareDefaultDependencies(project, configuration);
+        LessSourceSet sourceSet = createCustomSourceSet(project, DefaultLessSourceSet.class, "less");
+        createDefaultLessCompileTask(project, sourceSet.getLess(), configuration);
+        configureLessCompileTask(project);
+    }
+
+    private Configuration createLessCompilerConfiguration(Project project) {
+        Configuration configuration = project.getConfigurations().create(LESS_COMPILER_CONFIGURATION_NAME);
+        configuration.setVisible(false);
+        configuration.setTransitive(true);
+        configuration.setDescription("The LESS compiler library used to generate CSS stylesheets from LESS stylesheets.");
+        return configuration;
+    }
+
+    private void declareDefaultDependencies(Project project, Configuration configuration) {
+        configuration.defaultDependencies(dependencies -> {
+            dependencies.add(project.getDependencies().create(Less4jCompiler.getDependencyNotation()));
+        });
+    }
+
+    private void createDefaultLessCompileTask(Project project, SourceDirectorySet sourceDirectory, Configuration configuration) {
+        project.getTasks().register(LESS_COMPILE_TASK_NAME, LessCompile.class, task -> {
+            task.setDescription("Generates CSS stylesheets for the '" + sourceDirectory.getDisplayName() + "' source set.");
+            task.setSource(sourceDirectory);
+            task.getOutputDirectory().set(getOutputDir(project, sourceDirectory));
+            task.getLessCompilerClasspath().setFrom(configuration);
+        });
+    }
+
+    private void configureLessCompileTask(Project project) {
+        TaskProvider<LessCompile> lessCompileTaskProvider = project.getTasks().named(LESS_COMPILE_TASK_NAME, LessCompile.class);
+
+        project.getTasks().named(ASSEMBLE_TASK_NAME, task -> {
+            task.dependsOn(lessCompileTaskProvider);
+        });
+        project.getTasks().named(ASSETS_JAR_TASK_NAME, Jar.class, task -> {
+            task.dependsOn(lessCompileTaskProvider);
+            task.from(lessCompileTaskProvider.get().getOutputDirectory(), copySpec -> copySpec.into("public"));
+        });
+        project.getTasks().named(PLAY_RUN_TASK_NAME, PlayRun.class, task -> {
+            task.getAssetsDirs().from(lessCompileTaskProvider.get().getOutputDirectory());
+        });
+    }
+}

--- a/src/main/java/org/gradle/playframework/plugins/PlayWebJarsPlugin.java
+++ b/src/main/java/org/gradle/playframework/plugins/PlayWebJarsPlugin.java
@@ -1,0 +1,81 @@
+package org.gradle.playframework.plugins;
+
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.bundling.Jar;
+import org.gradle.playframework.tasks.LessCompile;
+import org.gradle.playframework.tasks.PlayRun;
+import org.gradle.playframework.tasks.WebJarsExtract;
+import org.gradle.playframework.tools.internal.webjars.WebJarsExtractor;
+
+import static org.gradle.api.plugins.BasePlugin.ASSEMBLE_TASK_NAME;
+import static org.gradle.playframework.plugins.PlayApplicationPlugin.ASSETS_JAR_TASK_NAME;
+import static org.gradle.playframework.plugins.PlayApplicationPlugin.PLAY_RUN_TASK_NAME;
+import static org.gradle.playframework.plugins.PlayLessPlugin.LESS_COMPILE_TASK_NAME;
+
+/**
+ * Plugin for extracting WebJars in a Play application.
+ */
+public class PlayWebJarsPlugin implements PlayGeneratedSourcePlugin {
+    public static final String WEBJAR_CONFIGURATION_NAME = "webJar";
+    public static final String WEBJARS_EXTRACTOR_CONFIGURATION_NAME = "webJarsExtractor";
+    public static final String WEBJARS_EXTRACT_TASK_NAME = "extractPlayWebJars";
+
+    @Override
+    public void apply(Project project) {
+        createWebJarConfiguration(project);
+        Configuration webJarsExtractorConfiguration = createWebJarsExtractorConfiguration(project);
+        declareDefaultDependencies(project, webJarsExtractorConfiguration);
+        createDefaultWebJarsExtractTask(project, webJarsExtractorConfiguration);
+        configureWebJarsExtractTask(project);
+    }
+
+    private void createWebJarConfiguration(Project project) {
+        Configuration configuration = project.getConfigurations().create(WEBJAR_CONFIGURATION_NAME);
+        configuration.setTransitive(true);
+    }
+
+    private Configuration createWebJarsExtractorConfiguration(Project project) {
+        Configuration configuration = project.getConfigurations().create(WEBJARS_EXTRACTOR_CONFIGURATION_NAME);
+        configuration.setVisible(false);
+        configuration.setTransitive(true);
+        configuration.setDescription("The WebJars extractor library used to extract WebJars.");
+        return configuration;
+    }
+
+    private void declareDefaultDependencies(Project project, Configuration configuration) {
+        configuration.defaultDependencies(dependencies -> {
+            dependencies.add(project.getDependencies().create(WebJarsExtractor.getDependencyNotation()));
+        });
+    }
+
+    private void createDefaultWebJarsExtractTask(Project project, Configuration configuration) {
+        project.getTasks().register(WEBJARS_EXTRACT_TASK_NAME, WebJarsExtract.class, task -> {
+            task.setDescription("Extracts WebJars.");
+            task.getOutputDirectory().set(project.getLayout().getBuildDirectory().dir(GENERATED_SOURCE_ROOT_DIR_PATH + "/webJars"));
+            task.getWebJarsClasspath().setFrom(project.getConfigurations().getByName(WEBJAR_CONFIGURATION_NAME));
+            task.getWebJarsExtractorClasspath().setFrom(configuration);
+        });
+    }
+
+    private void configureWebJarsExtractTask(Project project) {
+        TaskProvider<WebJarsExtract> webJarsExtractTaskProvider = project.getTasks().named(WEBJARS_EXTRACT_TASK_NAME, WebJarsExtract.class);
+
+        project.getTasks().named(ASSEMBLE_TASK_NAME, task -> {
+            task.dependsOn(webJarsExtractTaskProvider);
+        });
+        project.getTasks().named(ASSETS_JAR_TASK_NAME, Jar.class, task -> {
+            task.dependsOn(webJarsExtractTaskProvider);
+            task.from(webJarsExtractTaskProvider.get().getOutputDirectory(), copySpec -> copySpec.into("public"));
+        });
+        project.getTasks().named(PLAY_RUN_TASK_NAME, PlayRun.class, task -> {
+            task.getAssetsDirs().from(webJarsExtractTaskProvider.get().getOutputDirectory());
+        });
+        project.getTasks().matching(task -> task.getName().equals(LESS_COMPILE_TASK_NAME)).configureEach(task -> {
+            LessCompile lessCompileTask = (LessCompile) task;
+            lessCompileTask.dependsOn(webJarsExtractTaskProvider);
+            lessCompileTask.getIncludePaths().add(webJarsExtractTaskProvider.get().getOutputDirectory().get().getAsFile());
+        });
+    }
+}

--- a/src/main/java/org/gradle/playframework/sourcesets/LessSourceSet.java
+++ b/src/main/java/org/gradle/playframework/sourcesets/LessSourceSet.java
@@ -1,0 +1,38 @@
+package org.gradle.playframework.sourcesets;
+
+import org.gradle.api.Action;
+import org.gradle.api.file.SourceDirectorySet;
+
+/**
+ * Represents a source set containing LESS sources.
+ * <p>
+ * The following example demonstrate the use of the source set in a build script using the Groovy DSL:
+ * <pre>
+ * sourceSets {
+ *     main {
+ *         less {
+ *             srcDir 'app/assets'
+ *             include '{@literal **}/*.less'
+ *             exclude '{@literal **}/_*.less'
+ *         }
+ *     }
+ * }
+ * </pre>
+ */
+public interface LessSourceSet {
+
+    /**
+     * Returns the source directory set.
+     *
+     * @return The source directory set
+     */
+    SourceDirectorySet getLess();
+
+    /**
+     * Configures the source set.
+     *
+     * @param configureAction The configuration action
+     * @return The source set
+     */
+    LessSourceSet less(Action<? super SourceDirectorySet> configureAction);
+}

--- a/src/main/java/org/gradle/playframework/sourcesets/internal/DefaultLessSourceSet.java
+++ b/src/main/java/org/gradle/playframework/sourcesets/internal/DefaultLessSourceSet.java
@@ -1,0 +1,32 @@
+package org.gradle.playframework.sourcesets.internal;
+
+import org.gradle.api.Action;
+import org.gradle.api.file.SourceDirectorySet;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.playframework.sourcesets.LessSourceSet;
+
+import javax.inject.Inject;
+
+public class DefaultLessSourceSet implements LessSourceSet {
+
+    private final SourceDirectorySet less;
+
+    @Inject
+    public DefaultLessSourceSet(String name, String displayName, ObjectFactory objectFactory) {
+        less = objectFactory.sourceDirectorySet(name, displayName +  " LESS source");
+        less.srcDirs("app/assets");
+        less.include("**/*.less");
+        less.exclude("**/_*.less");
+    }
+
+    @Override
+    public SourceDirectorySet getLess() {
+        return less;
+    }
+
+    @Override
+    public LessSourceSet less(Action<? super SourceDirectorySet> configureAction) {
+        configureAction.execute(getLess());
+        return this;
+    }
+}

--- a/src/main/java/org/gradle/playframework/tasks/LessCompile.java
+++ b/src/main/java/org/gradle/playframework/tasks/LessCompile.java
@@ -1,0 +1,92 @@
+package org.gradle.playframework.tasks;
+
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.Directory;
+import org.gradle.api.file.FileTree;
+import org.gradle.api.file.FileVisitDetails;
+import org.gradle.api.file.FileVisitor;
+import org.gradle.api.internal.file.RelativeFile;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.SourceTask;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.playframework.tasks.internal.LessCompileRunnable;
+import org.gradle.playframework.tools.internal.less.DefaultLessCompileSpec;
+import org.gradle.playframework.tools.internal.less.Less4jCompiler;
+import org.gradle.playframework.tools.internal.less.LessCompileSpec;
+import org.gradle.workers.IsolationMode;
+import org.gradle.workers.WorkerExecutor;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class LessCompile extends SourceTask {
+    private final WorkerExecutor workerExecutor;
+    private final Property<Directory> outputDirectory;
+    private final ConfigurableFileCollection lessCompilerClasspath;
+    private final List<File> lessCompilerIncludePaths;
+
+    @Inject
+    public LessCompile(WorkerExecutor workerExecutor) {
+        this.workerExecutor = workerExecutor;
+        this.outputDirectory = getProject().getObjects().directoryProperty();
+        this.lessCompilerClasspath = getProject().files();
+        this.lessCompilerIncludePaths = new ArrayList<>();
+    }
+
+    @Override
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public FileTree getSource() {
+        return super.getSource();
+    }
+
+    @OutputDirectory
+    public Property<Directory> getOutputDirectory() {
+        return outputDirectory;
+    }
+
+    @Classpath
+    public ConfigurableFileCollection getLessCompilerClasspath() {
+        return lessCompilerClasspath;
+    }
+
+    @InputFiles
+    public List<File> getIncludePaths() {
+        return lessCompilerIncludePaths;
+    }
+
+    @TaskAction
+    void compile() {
+        RelativeFileCollector relativeFileCollector = new RelativeFileCollector();
+        getSource().visit(relativeFileCollector);
+        final LessCompileSpec spec = new DefaultLessCompileSpec(relativeFileCollector.relativeFiles, getOutputDirectory().get().getAsFile(), getIncludePaths());
+
+        workerExecutor.submit(LessCompileRunnable.class, workerConfiguration -> {
+            workerConfiguration.setIsolationMode(IsolationMode.PROCESS);
+            workerConfiguration.forkOptions(options -> options.jvmArgs("-XX:MaxMetaspaceSize=256m"));
+            workerConfiguration.params(spec, new Less4jCompiler());
+            workerConfiguration.classpath(lessCompilerClasspath);
+            workerConfiguration.setDisplayName("Generating CSS stylesheets from LESS stylesheets");
+        });
+        workerExecutor.await();
+    }
+
+    private static class RelativeFileCollector implements FileVisitor {
+        List<RelativeFile> relativeFiles = new ArrayList<>();
+
+        @Override
+        public void visitDir(FileVisitDetails dirDetails) {
+        }
+
+        @Override
+        public void visitFile(FileVisitDetails fileDetails) {
+            relativeFiles.add(new RelativeFile(fileDetails.getFile(), fileDetails.getRelativePath()));
+        }
+    }
+}

--- a/src/main/java/org/gradle/playframework/tasks/WebJarsExtract.java
+++ b/src/main/java/org/gradle/playframework/tasks/WebJarsExtract.java
@@ -1,0 +1,62 @@
+package org.gradle.playframework.tasks;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.Directory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.playframework.tasks.internal.WebJarsExtractRunnable;
+import org.gradle.playframework.tools.internal.webjars.DefaultWebJarsExtractSpec;
+import org.gradle.playframework.tools.internal.webjars.WebJarsExtractSpec;
+import org.gradle.workers.IsolationMode;
+import org.gradle.workers.WorkerExecutor;
+
+import javax.inject.Inject;
+
+public class WebJarsExtract extends DefaultTask {
+    private final WorkerExecutor workerExecutor;
+    private final Property<Directory> outputDirectory;
+    private final ConfigurableFileCollection webJarsClasspath;
+    private final ConfigurableFileCollection webJarsExtractorClasspath;
+
+    @Inject
+    public WebJarsExtract(WorkerExecutor workerExecutor) {
+        this.workerExecutor = workerExecutor;
+        this.outputDirectory = getProject().getObjects().directoryProperty();
+        this.webJarsClasspath = getProject().files();
+        this.webJarsExtractorClasspath = getProject().files();
+    }
+
+    @OutputDirectory
+    public Property<Directory> getOutputDirectory() {
+        return outputDirectory;
+    }
+
+    @InputFiles
+    public ConfigurableFileCollection getWebJarsClasspath() {
+        return webJarsClasspath;
+    }
+
+    @Classpath
+    public ConfigurableFileCollection getWebJarsExtractorClasspath() {
+        return webJarsExtractorClasspath;
+    }
+
+    @TaskAction
+    public void extract() {
+        final WebJarsExtractSpec spec = new DefaultWebJarsExtractSpec(getWebJarsClasspath().getFiles(), getOutputDirectory().get().getAsFile());
+
+        workerExecutor.submit(WebJarsExtractRunnable.class, workerConfiguration -> {
+            workerConfiguration.setIsolationMode(IsolationMode.PROCESS);
+            workerConfiguration.forkOptions(options -> options.jvmArgs("-XX:MaxMetaspaceSize=256m"));
+            workerConfiguration.params(spec);
+            workerConfiguration.classpath(webJarsExtractorClasspath);
+            workerConfiguration.setDisplayName("Extracting WebJars");
+        });
+
+        workerExecutor.await();
+    }
+}

--- a/src/main/java/org/gradle/playframework/tasks/internal/LessCompileRunnable.java
+++ b/src/main/java/org/gradle/playframework/tasks/internal/LessCompileRunnable.java
@@ -1,0 +1,25 @@
+package org.gradle.playframework.tasks.internal;
+
+import org.gradle.playframework.tools.internal.Compiler;
+import org.gradle.playframework.tools.internal.less.LessCompileSpec;
+import org.gradle.util.GFileUtils;
+
+import javax.inject.Inject;
+
+public class LessCompileRunnable implements Runnable {
+
+    private final LessCompileSpec lessCompileSpec;
+    private final Compiler<LessCompileSpec> compiler;
+
+    @Inject
+    public LessCompileRunnable(LessCompileSpec lessCompileSpec, Compiler<LessCompileSpec> compiler) {
+        this.lessCompileSpec = lessCompileSpec;
+        this.compiler = compiler;
+    }
+
+    @Override
+    public void run() {
+        GFileUtils.forceDelete(lessCompileSpec.getDestinationDir());
+        compiler.execute(lessCompileSpec);
+    }
+}

--- a/src/main/java/org/gradle/playframework/tasks/internal/WebJarsExtractRunnable.java
+++ b/src/main/java/org/gradle/playframework/tasks/internal/WebJarsExtractRunnable.java
@@ -1,0 +1,22 @@
+package org.gradle.playframework.tasks.internal;
+
+import org.gradle.playframework.tools.internal.webjars.WebJarsExtractSpec;
+import org.gradle.playframework.tools.internal.webjars.WebJarsExtractor;
+import org.gradle.util.GFileUtils;
+
+import javax.inject.Inject;
+
+public class WebJarsExtractRunnable implements Runnable {
+    private final WebJarsExtractSpec spec;
+
+    @Inject
+    public WebJarsExtractRunnable(WebJarsExtractSpec spec) {
+        this.spec = spec;
+    }
+
+    @Override
+    public void run() {
+        GFileUtils.forceDelete(spec.getDestinationDir());
+        new WebJarsExtractor().execute(spec);
+    }
+}

--- a/src/main/java/org/gradle/playframework/tools/internal/less/DefaultLessCompileSpec.java
+++ b/src/main/java/org/gradle/playframework/tools/internal/less/DefaultLessCompileSpec.java
@@ -1,0 +1,33 @@
+package org.gradle.playframework.tools.internal.less;
+
+import org.gradle.api.internal.file.RelativeFile;
+
+import java.io.File;
+import java.util.List;
+
+public class DefaultLessCompileSpec implements LessCompileSpec {
+    private final Iterable<RelativeFile> sourceFiles;
+    private final File destinationDir;
+    private final List<File> includePaths;
+
+    public DefaultLessCompileSpec(Iterable<RelativeFile> sourceFiles, File destinationDir, List<File> includePaths) {
+        this.sourceFiles = sourceFiles;
+        this.destinationDir = destinationDir;
+        this.includePaths = includePaths;
+    }
+
+    @Override
+    public Iterable<RelativeFile> getSources() {
+        return sourceFiles;
+    }
+
+    @Override
+    public File getDestinationDir() {
+        return destinationDir;
+    }
+
+    @Override
+    public List<File> getIncludePaths() {
+        return includePaths;
+    }
+}

--- a/src/main/java/org/gradle/playframework/tools/internal/less/Less4jCompiler.java
+++ b/src/main/java/org/gradle/playframework/tools/internal/less/Less4jCompiler.java
@@ -1,0 +1,108 @@
+package org.gradle.playframework.tools.internal.less;
+
+import org.gradle.api.file.RelativePath;
+import org.gradle.api.internal.file.RelativeFile;
+import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.WorkResults;
+import org.gradle.playframework.tools.internal.Compiler;
+import org.gradle.playframework.tools.internal.reflection.DirectInstantiator;
+import org.gradle.playframework.tools.internal.reflection.JavaMethod;
+import org.gradle.playframework.tools.internal.reflection.JavaReflectionUtil;
+import org.gradle.util.GFileUtils;
+
+import java.io.File;
+import java.io.Serializable;
+
+public class Less4jCompiler implements Compiler<LessCompileSpec>, Serializable {
+
+    private Class<Object> sourceClass;
+    private Class<Object> multiSourceClass;
+    private Class<Object> configurationClass;
+    private Class<Object> resultClass;
+    private Class<Object> compilerClass;
+
+    public static Object getDependencyNotation() {
+        return "com.github.sommeri:less4j:1.17.2";
+    }
+
+    @Override
+    public WorkResult execute(LessCompileSpec spec) {
+        boolean didWork = false;
+        File[] includePaths = spec.getIncludePaths().toArray(new File[0]);
+        for (RelativeFile lessFile : spec.getSources()) {
+            File cssFile = new File(
+                    spec.getDestinationDir(),
+                    toCss(lessFile.getRelativePath()).getPathString());
+
+            didWork |= compile(lessFile.getFile(), cssFile, includePaths);
+        }
+        return WorkResults.didWork(didWork);
+    }
+
+    private boolean compile(File lessFile, File cssFile, File[] includePaths) {
+        loadCompilerClasses(getClass().getClassLoader());
+
+        Object lessSource = DirectInstantiator.INSTANCE.newInstance(multiSourceClass, lessFile, includePaths);
+        Object options = DirectInstantiator.INSTANCE.newInstance(configurationClass);
+
+        JavaMethod<Object, Void> setCssResultLocation = JavaReflectionUtil.method(configurationClass, Void.class, "setCssResultLocation", File.class);
+        setCssResultLocation.invoke(options, cssFile);
+
+        JavaMethod<Object, Object> setCompressing = JavaReflectionUtil.method(configurationClass, configurationClass, "setCompressing", boolean.class);
+        setCompressing.invoke(options, true);
+
+        Object compiler = DirectInstantiator.INSTANCE.newInstance(compilerClass);
+
+        JavaMethod<Object, Object> doCompile = JavaReflectionUtil.method(compilerClass, Object.class, "compile", sourceClass, configurationClass);
+        Object result = doCompile.invoke(compiler, lessSource, options);
+
+        JavaMethod<Object, String> getCss = JavaReflectionUtil.method(resultClass, String.class, "getCss");
+        String css = getCss.invoke(result);
+
+        GFileUtils.writeFile(css, cssFile);
+        return true;
+    }
+
+    private void loadCompilerClasses(ClassLoader cl) {
+        try {
+            if (sourceClass == null) {
+                @SuppressWarnings("unchecked")
+                Class<Object> clazz = (Class<Object>) cl.loadClass("com.github.sommeri.less4j.LessSource");
+                sourceClass = clazz;
+            }
+            if (multiSourceClass == null) {
+                @SuppressWarnings("unchecked")
+                Class<Object> clazz = (Class<Object>) cl.loadClass("com.github.sommeri.less4j.MultiPathFileSource");
+                multiSourceClass = clazz;
+            }
+            if (configurationClass == null) {
+                @SuppressWarnings("unchecked")
+                Class<Object> clazz = (Class<Object>) cl.loadClass("com.github.sommeri.less4j.LessCompiler$Configuration");
+                configurationClass = clazz;
+            }
+            if (resultClass == null) {
+                @SuppressWarnings("unchecked")
+                Class<Object> clazz = (Class<Object>) cl.loadClass("com.github.sommeri.less4j.LessCompiler$CompilationResult");
+                resultClass = clazz;
+            }
+            if (compilerClass == null) {
+                @SuppressWarnings("unchecked")
+                Class<Object> clazz = (Class<Object>) cl.loadClass("com.github.sommeri.less4j.core.ThreadUnsafeLessCompiler");
+                compilerClass = clazz;
+            }
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Failed to load classes for Less4jCompiler", e);
+        }
+    }
+
+    private static RelativePath toCss(RelativePath path) {
+        String lessFilename = path.getLastName();
+        String cssFilename;
+        if (lessFilename.endsWith(".less")) {
+            cssFilename = lessFilename.substring(0, lessFilename.length() - ".less".length()) + ".css";
+        } else {
+            cssFilename = lessFilename + ".css";
+        }
+        return path.replaceLastName(cssFilename);
+    }
+}

--- a/src/main/java/org/gradle/playframework/tools/internal/less/LessCompileSpec.java
+++ b/src/main/java/org/gradle/playframework/tools/internal/less/LessCompileSpec.java
@@ -1,0 +1,14 @@
+package org.gradle.playframework.tools.internal.less;
+
+import org.gradle.api.internal.file.RelativeFile;
+import org.gradle.playframework.tools.internal.PlayCompileSpec;
+
+import java.io.File;
+import java.io.Serializable;
+import java.util.List;
+
+public interface LessCompileSpec extends PlayCompileSpec, Serializable {
+    Iterable<RelativeFile> getSources();
+
+    List<File> getIncludePaths();
+}

--- a/src/main/java/org/gradle/playframework/tools/internal/webjars/DefaultWebJarsExtractSpec.java
+++ b/src/main/java/org/gradle/playframework/tools/internal/webjars/DefaultWebJarsExtractSpec.java
@@ -1,0 +1,24 @@
+package org.gradle.playframework.tools.internal.webjars;
+
+import java.io.File;
+import java.util.Set;
+
+public class DefaultWebJarsExtractSpec implements WebJarsExtractSpec {
+    private final Set<File> classpath;
+    private final File destinationDir;
+
+    public DefaultWebJarsExtractSpec(Set<File> classpath, File destinationDir) {
+        this.classpath = classpath;
+        this.destinationDir = destinationDir;
+    }
+
+    @Override
+    public Set<File> getClasspath() {
+        return classpath;
+    }
+
+    @Override
+    public File getDestinationDir() {
+        return destinationDir;
+    }
+}

--- a/src/main/java/org/gradle/playframework/tools/internal/webjars/WebJarsExtractSpec.java
+++ b/src/main/java/org/gradle/playframework/tools/internal/webjars/WebJarsExtractSpec.java
@@ -1,0 +1,11 @@
+package org.gradle.playframework.tools.internal.webjars;
+
+import java.io.File;
+import java.io.Serializable;
+import java.util.Set;
+
+public interface WebJarsExtractSpec extends Serializable {
+    Set<File> getClasspath();
+
+    File getDestinationDir();
+}

--- a/src/main/java/org/gradle/playframework/tools/internal/webjars/WebJarsExtractor.java
+++ b/src/main/java/org/gradle/playframework/tools/internal/webjars/WebJarsExtractor.java
@@ -1,0 +1,62 @@
+package org.gradle.playframework.tools.internal.webjars;
+
+import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.WorkResults;
+import org.gradle.playframework.tools.internal.reflection.DirectInstantiator;
+import org.gradle.playframework.tools.internal.reflection.JavaMethod;
+import org.gradle.playframework.tools.internal.reflection.JavaReflectionUtil;
+
+import java.io.File;
+import java.io.Serializable;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+
+public class WebJarsExtractor implements Serializable  {
+
+    private Class<Object> extractorClass;
+
+    public static Object getDependencyNotation() {
+        return "org.webjars:webjars-locator-core:0.32";
+    }
+
+    public WorkResult execute(WebJarsExtractSpec spec) {
+        List<URL> urls = new ArrayList<>();
+
+        spec.getClasspath().forEach(file -> {
+            try {
+                urls.add(file.toURI().toURL());
+            } catch (MalformedURLException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        URLClassLoader classLoader = new URLClassLoader(urls.toArray(new URL[urls.size()]));
+
+        loadCompilerClasses(getClass().getClassLoader());
+
+        Object extractor = DirectInstantiator.INSTANCE.newInstance(extractorClass, classLoader);
+
+        JavaMethod<Object, Void> extractAllWebJarsTo = JavaReflectionUtil.method(extractorClass, Void.class, "extractAllWebJarsTo", File.class);
+        extractAllWebJarsTo.invoke(extractor, new File(spec.getDestinationDir(), "lib"));
+
+        JavaMethod<Object, Void> extractAllNodeModulesTo = JavaReflectionUtil.method(extractorClass, Void.class, "extractAllNodeModulesTo", File.class);
+        extractAllNodeModulesTo.invoke(extractor, new File(spec.getDestinationDir(), "lib"));
+
+        return WorkResults.didWork(true);
+    }
+
+    private void loadCompilerClasses(ClassLoader cl) {
+        try {
+            if (extractorClass == null) {
+                @SuppressWarnings("unchecked")
+                Class<Object> clazz = (Class<Object>) cl.loadClass("org.webjars.WebJarExtractor");
+                extractorClass = clazz;
+            }
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Failed to load classes for WebJarsExtractor", e);
+        }
+    }
+}


### PR DESCRIPTION
- Full support for WebJars as described here: https://www.playframework.com/documentation/2.8.x/AssetsOverview#WebJars
  * Add plugin `org.gradle.playframework-webjars`
  * Add `webJar` configuration for adding dependency to WebJar libraries, e.g.
    
          dependencies {
              webJar 'org.webjars:requirejs:2.3.6'
          }
  * Extracted jars are under `lib/` in the assets jar
  * Implementation: https://github.com/webjars/webjars-locator-core

- Full support for LESS as described here: 
https://www.playframework.com/documentation/2.8.x/AssetsLess
  * Add plugin `org.gradle.playframework-less`
  * Add `less` source set
  * Can import partials (`_*.less`)
  * Can import sources from `lib/` generated by WebJars above
  * Implementation: https://github.com/SomMeri/less4j

- Include the following to the `runPlay`'s assets dirs so that the compiled/generated assets can be served during development mode:
  * WebJars outputs
  * Compiled LESS -> CSS outputs
  * Minified JavaScript (https://github.com/gradle/playframework/pull/132/files#diff-e7ebc2272b935d9432ec15917a15b01eR52)

- Add integration tests

- Add asset pipelines docs