### PR TITLE
Add Play 2.8 support

### DIFF
--- a/src/docs/asciidoc/00-intro.adoc
+++ b/src/docs/asciidoc/00-intro.adoc
@@ -13,7 +13,7 @@ The Play plugin defines the following requirements for a consuming build.
 
 * The build has to be run with Java 8 or higher.
 * The build has to use Gradle 5.0 or higher.
-* The supported Play versions are 2.4.x, 2.5.x and 2.6.x.
+* The supported Play versions are 2.4.x, 2.5.x, 2.6.x, 2.7.x, and 2.8.x.
 
 === Limitations
 

--- a/src/docs/asciidoc/11-play-framework.adoc
+++ b/src/docs/asciidoc/11-play-framework.adoc
@@ -9,6 +9,10 @@ The following versions of Play and Scala are supported:
 |===
 | Play | Scala | Java
 
+| 2.8.x
+| 2.12 and 2.13
+| 1.8
+
 | 2.7.x
 | 2.11, 2.12 and 2.13
 | 1.8

--- a/src/integTestFixtures/groovy/org/gradle/playframework/fixtures/multiversion/PlayCoverage.groovy
+++ b/src/integTestFixtures/groovy/org/gradle/playframework/fixtures/multiversion/PlayCoverage.groovy
@@ -14,8 +14,7 @@ final class PlayCoverage {
             VersionNumber.parse('2.4.11'),
             VersionNumber.parse('2.5.19'),
             VersionNumber.parse('2.7.3'),
-            // Not supported yet
-            // VersionNumber.parse('2.8.0'),
+            VersionNumber.parse('2.8.1'),
             DEFAULT
     ]
 }

--- a/src/main/java/org/gradle/playframework/extensions/internal/PlayMajorVersion.java
+++ b/src/main/java/org/gradle/playframework/extensions/internal/PlayMajorVersion.java
@@ -13,9 +13,8 @@ public enum PlayMajorVersion {
     PLAY_2_4_X("2.4.x", true, "2.11", "2.10"),
     PLAY_2_5_X("2.5.x", true,"2.11"),
     PLAY_2_6_X("2.6.x", true, "2.12", "2.11"),
-    PLAY_2_7_X("2.7.x", false, "2.13", "2.12", "2.11");
-    // Not supported yet
-    // PLAY_2_8_X("2.8.x", false, "2.13", "2.12");
+    PLAY_2_7_X("2.7.x", false, "2.13", "2.12", "2.11"),
+    PLAY_2_8_X("2.8.x", false, "2.13", "2.12");
 
     private final String name;
     private final boolean supportForStaticRoutes;

--- a/src/main/java/org/gradle/playframework/plugins/PlayApplicationPlugin.java
+++ b/src/main/java/org/gradle/playframework/plugins/PlayApplicationPlugin.java
@@ -102,6 +102,7 @@ public class PlayApplicationPlugin implements Plugin<Project> {
             // if the project is Java or Scala based.
             case PLAY_2_6_X:
             case PLAY_2_7_X:
+            case PLAY_2_8_X:
                 dependencies.add(PLATFORM_CONFIGURATION, playPlatform.getDependencyNotation("play-java-forms").get());
         }
     }

--- a/src/main/java/org/gradle/playframework/plugins/PlayDistributionPlugin.java
+++ b/src/main/java/org/gradle/playframework/plugins/PlayDistributionPlugin.java
@@ -125,10 +125,6 @@ public class PlayDistributionPlugin implements Plugin<Project> {
         switch (PlayMajorVersion.forPlatform(playPlatform)) {
             case PLAY_2_3_X:
                 return "play.core.server.NettyServer";
-            case PLAY_2_4_X:
-            case PLAY_2_5_X:
-            case PLAY_2_6_X:
-            case PLAY_2_7_X:
             default:
                 return "play.core.server.ProdServerStart";
         }

--- a/src/main/java/org/gradle/playframework/tools/internal/routes/RoutesCompilerFactory.java
+++ b/src/main/java/org/gradle/playframework/tools/internal/routes/RoutesCompilerFactory.java
@@ -24,6 +24,7 @@ public class RoutesCompilerFactory {
             case PLAY_2_6_X:
                 return new RoutesCompilerAdapterV24X(playVersion, scalaVersion);
             case PLAY_2_7_X:
+            case PLAY_2_8_X:
             default:
                 return new RoutesCompilerAdapterV27X(playVersion, scalaVersion);
         }

--- a/src/main/java/org/gradle/playframework/tools/internal/twirl/TwirlCompilerFactory.java
+++ b/src/main/java/org/gradle/playframework/tools/internal/twirl/TwirlCompilerFactory.java
@@ -21,8 +21,10 @@ public class TwirlCompilerFactory {
             case PLAY_2_6_X:
                 return new TwirlCompilerAdapterV13X("1.3.13", scalaCompatibilityVersion, playTwirlAdapter);
             case PLAY_2_7_X:
-            default:
                 return new TwirlCompilerAdapterV13X("1.4.2", scalaCompatibilityVersion, playTwirlAdapter);
+            case PLAY_2_8_X:
+            default:
+                return new TwirlCompilerAdapterV13X("1.5.0", scalaCompatibilityVersion, playTwirlAdapter);
         }
     }
 
@@ -32,8 +34,6 @@ public class TwirlCompilerFactory {
             case PLAY_2_4_X:
             case PLAY_2_5_X:
                 return new PlayTwirlAdapterV23X();
-            case PLAY_2_6_X:
-            case PLAY_2_7_X:
             default:
                 return new PlayTwirlAdapterV26X();
         }


### PR DESCRIPTION
Play 2.8 mostly matches Play 2.7, but drops support for Scala 2.11 and uses a newer version of Twirl by default.

Travis is failing for all PRs right now. This won't change that. But it probably doesn't hurt to merge it since it's a pretty simple one