### PR TITLE
Fix 0.9 release date in changes

### DIFF
--- a/src/docs/asciidoc/50-changes.adoc
+++ b/src/docs/asciidoc/50-changes.adoc
@@ -10,7 +10,7 @@
 * https://github.com/arjunchhabra[arjunchhabra] - Add preliminary support for Play 2.7.X
 
 [discrete]
-=== v0.9 (2018-08-09)
+=== v0.9 (2019-08-20)
 
 * Add workaround for multiple SLF4J bindings on classpath for runPlay 
 


### PR DESCRIPTION
0.9 was released 2019 and the tag was created on 2019-08-20.