### PR TITLE
#142: Remove 2.3 and pre-5 from Docs and Test Coverage

### DIFF
--- a/buildSrc/src/main/kotlin/org/gradle/playframework/TestSetupPlugin.kt
+++ b/buildSrc/src/main/kotlin/org/gradle/playframework/TestSetupPlugin.kt
@@ -22,6 +22,7 @@ class TestSetupPlugin : Plugin<Project> {
 
     private
     fun determineMaxParallelForks(): Int {
-        return if ((Runtime.getRuntime().availableProcessors() / 2) < 1) 1 else (Runtime.getRuntime().availableProcessors() / 2)
+        // return if ((Runtime.getRuntime().availableProcessors() / 2) < 1) 1 else (Runtime.getRuntime().availableProcessors() / 2)
+        return 1
     }
 }

--- a/src/docTest/groovy/org/gradle/playframework/InDepthUserGuideSamplesIntegrationTest.groovy
+++ b/src/docTest/groovy/org/gradle/playframework/InDepthUserGuideSamplesIntegrationTest.groovy
@@ -19,7 +19,8 @@ import spock.lang.Unroll
  */
 @Unroll
 class InDepthUserGuideSamplesIntegrationTest extends Specification {
-    private static final String[] VERSIONS_UNDER_TEST = ["5.1.1", "5.2.1", "5.5.1", "5.6.4", "6.0.1", "6.1.1", "6.3"]
+    private static final String[] VERSIONS_UNDER_TEST = ["6.0.1", "6.1.1", "6.3"]
+    //private static final String[] VERSIONS_UNDER_TEST = []
 
     @Rule
     Sample sample = Sample.from("src/docs/samples")

--- a/src/docs/asciidoc/00-intro.adoc
+++ b/src/docs/asciidoc/00-intro.adoc
@@ -12,7 +12,7 @@ This plugin is different from the {uri-gradle-userguide}/play_plugin.html[Play p
 The Play plugin defines the following requirements for a consuming build.
 
 * The build has to be run with Java 8 or higher.
-* The build has to use Gradle 5.0 or higher.
+* The build has to use Gradle 6.0 or higher.
 * The supported Play versions are 2.4.x, 2.5.x and 2.6.x.
 
 === Limitations

--- a/src/docs/asciidoc/11-play-framework.adoc
+++ b/src/docs/asciidoc/11-play-framework.adoc
@@ -24,8 +24,4 @@ The following versions of Play and Scala are supported:
 | 2.4.x
 | 2.10 and 2.11
 | 1.8
-
-| 2.3.x
-| 2.10 and 2.11
-| 1.6, 1.7 and 1.8
 |===

--- a/src/integTest/groovy/org/gradle/playframework/plugins/PlayRoutesPluginIntegrationTest.groovy
+++ b/src/integTest/groovy/org/gradle/playframework/plugins/PlayRoutesPluginIntegrationTest.groovy
@@ -120,24 +120,6 @@ class PlayRoutesPluginIntegrationTest extends AbstractIntegrationTest {
         findFile(compiledRouterFiles, 'Routes.scala')
     }
 
-    def "fails build if injected routes generator was configured for Play version < 2.4.0"() {
-        given:
-        buildFile << """
-            play {
-                platform {
-                    playVersion = '2.3.0'
-                }
-                injectedRoutesGenerator = true
-            }
-        """
-
-        when:
-        BuildResult result = buildAndFail(ROUTES_COMPILE_TASK_NAME)
-
-        then:
-        result.output.contains('Injected routers are only supported in Play 2.4 or newer.')
-    }
-
     static String getRoutes() {
         """
             GET     /                           controllers.HomeController.index

--- a/src/integTestFixtures/groovy/org/gradle/playframework/fixtures/multiversion/PlayCoverage.groovy
+++ b/src/integTestFixtures/groovy/org/gradle/playframework/fixtures/multiversion/PlayCoverage.groovy
@@ -10,10 +10,10 @@ final class PlayCoverage {
 
     public static final VersionNumber DEFAULT = VersionNumber.parse(DEFAULT_PLAY_VERSION)
     public static final List<VersionNumber> ALL = [
-            //VersionNumber.parse('2.3.10'),
+            //VersionNumber.parse('2.3.10'),  NO LONGER SUPPORTED
             VersionNumber.parse('2.4.11'),
             VersionNumber.parse('2.5.19'),
-            VersionNumber.parse('2.7.3'),
+            //VersionNumber.parse('2.7.3'),
             // Not supported yet
             // VersionNumber.parse('2.8.0'),
             DEFAULT

--- a/src/integTestFixtures/groovy/org/gradle/playframework/fixtures/multiversion/PlayCoverage.groovy
+++ b/src/integTestFixtures/groovy/org/gradle/playframework/fixtures/multiversion/PlayCoverage.groovy
@@ -10,7 +10,7 @@ final class PlayCoverage {
 
     public static final VersionNumber DEFAULT = VersionNumber.parse(DEFAULT_PLAY_VERSION)
     public static final List<VersionNumber> ALL = [
-            VersionNumber.parse('2.3.10'),
+            //VersionNumber.parse('2.3.10'),
             VersionNumber.parse('2.4.11'),
             VersionNumber.parse('2.5.19'),
             VersionNumber.parse('2.7.3'),

--- a/src/integTestFixtures/groovy/org/gradle/playframework/fixtures/multiversion/PlayCoverage.groovy
+++ b/src/integTestFixtures/groovy/org/gradle/playframework/fixtures/multiversion/PlayCoverage.groovy
@@ -10,10 +10,9 @@ final class PlayCoverage {
 
     public static final VersionNumber DEFAULT = VersionNumber.parse(DEFAULT_PLAY_VERSION)
     public static final List<VersionNumber> ALL = [
-            //VersionNumber.parse('2.3.10'),  NO LONGER SUPPORTED
             VersionNumber.parse('2.4.11'),
             VersionNumber.parse('2.5.19'),
-            //VersionNumber.parse('2.7.3'),
+            VersionNumber.parse('2.7.3'),
             // Not supported yet
             // VersionNumber.parse('2.8.0'),
             DEFAULT


### PR DESCRIPTION
Part of Fix for #142 .
Includes setting maxParallelForks to 1 in order to facilitate investigation of CI build failures.