### PR TITLE
Reset idea dependencies to avoid compiling all sources

### DIFF
--- a/src/integTest/groovy/org/gradle/playframework/application/PlayIdePluginIntegrationTest.groovy
+++ b/src/integTest/groovy/org/gradle/playframework/application/PlayIdePluginIntegrationTest.groovy
@@ -10,6 +10,7 @@ abstract class PlayIdePluginIntegrationTest extends PlayMultiVersionApplicationI
     abstract String getIdeTask()
     abstract List<File> getIdeFiles()
     abstract String[] getBuildTasks()
+    abstract String[] getUnexecutedTasks()
 
     def "generates IDE configuration"() {
         applyIdePlugin()
@@ -18,6 +19,9 @@ abstract class PlayIdePluginIntegrationTest extends PlayMultiVersionApplicationI
         then:
         buildTasks.each {
             assert result.task(it).outcome == TaskOutcome.SUCCESS
+        }
+        unexecutedTasks.each {
+            assert !result.task(it)
         }
         ideFiles.each {
             assert it.exists()

--- a/src/integTest/groovy/org/gradle/playframework/application/advanced/PlayIdeaPluginAdvancedIntegrationTest.groovy
+++ b/src/integTest/groovy/org/gradle/playframework/application/advanced/PlayIdeaPluginAdvancedIntegrationTest.groovy
@@ -5,11 +5,15 @@ import org.gradle.playframework.application.PlayIdeaPluginIntegrationTest
 import org.gradle.playframework.fixtures.app.AdvancedPlayApp
 import org.gradle.playframework.fixtures.app.PlayApp
 
+import static org.gradle.api.plugins.JavaPlugin.CLASSES_TASK_NAME
 import static org.gradle.playframework.plugins.PlayJavaScriptPlugin.JS_MINIFY_TASK_NAME
 import static org.gradle.playframework.plugins.PlayRoutesPlugin.ROUTES_COMPILE_TASK_NAME
 import static org.gradle.playframework.plugins.PlayTwirlPlugin.TWIRL_COMPILE_TASK_NAME
 
 class PlayIdeaPluginAdvancedIntegrationTest extends PlayIdeaPluginIntegrationTest {
+    private static final String CLASSES_TASK_PATH = ":$CLASSES_TASK_NAME".toString()
+    private static final String SCALA_COMPILE_TASK_NAME = 'compileScala'
+    private static final String SCALA_COMPILE_TASK_PATH = ":$SCALA_COMPILE_TASK_NAME".toString()
     private static final String ROUTES_COMPILE_TASK_PATH = ":$ROUTES_COMPILE_TASK_NAME".toString()
     private static final String TWIRL_COMPILE_TASK_PATH = ":$TWIRL_COMPILE_TASK_NAME".toString()
     private static final String JS_MINIFY_TASK_PATH = ":$JS_MINIFY_TASK_NAME".toString()
@@ -44,6 +48,13 @@ class PlayIdeaPluginAdvancedIntegrationTest extends PlayIdeaPluginIntegrationTes
             ":ideaModule",
             ":ideaWorkspace",
             ":idea"
+        ]
+    }
+
+    String[] getUnexecutedTasks() {
+        [
+            CLASSES_TASK_PATH,
+            SCALA_COMPILE_TASK_PATH
         ]
     }
 

--- a/src/integTest/groovy/org/gradle/playframework/application/basic/PlayIdeaPluginBasicIntegrationTest.groovy
+++ b/src/integTest/groovy/org/gradle/playframework/application/basic/PlayIdeaPluginBasicIntegrationTest.groovy
@@ -7,11 +7,15 @@ import org.gradle.playframework.fixtures.app.PlayApp
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 
+import static org.gradle.api.plugins.JavaPlugin.CLASSES_TASK_NAME
 import static org.gradle.playframework.fixtures.ide.IdeaFixtures.parseIml
 import static org.gradle.playframework.plugins.PlayRoutesPlugin.ROUTES_COMPILE_TASK_NAME
 import static org.gradle.playframework.plugins.PlayTwirlPlugin.TWIRL_COMPILE_TASK_NAME
 
 class PlayIdeaPluginBasicIntegrationTest extends PlayIdeaPluginIntegrationTest {
+    private static final String CLASSES_TASK_PATH = ":$CLASSES_TASK_NAME".toString()
+    private static final String SCALA_COMPILE_TASK_NAME = 'compileScala'
+    private static final String SCALA_COMPILE_TASK_PATH = ":$SCALA_COMPILE_TASK_NAME".toString()
     private static final String ROUTES_COMPILE_TASK_PATH = ":$ROUTES_COMPILE_TASK_NAME".toString()
     private static final String TWIRL_COMPILE_TASK_PATH = ":$TWIRL_COMPILE_TASK_NAME".toString()
     static final Map PLAY_VERSION_TO_CLASSPATH_SIZE = [(PlayMajorVersion.PLAY_2_4_X): 96,
@@ -42,6 +46,13 @@ class PlayIdeaPluginBasicIntegrationTest extends PlayIdeaPluginIntegrationTest {
             ":ideaModule",
             ":ideaWorkspace",
             ":idea"
+        ]
+    }
+
+    String[] getUnexecutedTasks() {
+        [
+            SCALA_COMPILE_TASK_PATH,
+            CLASSES_TASK_PATH
         ]
     }
 

--- a/src/integTest/groovy/org/gradle/playframework/application/multiproject/PlayIdeaPluginMultiprojectIntegrationTest.groovy
+++ b/src/integTest/groovy/org/gradle/playframework/application/multiproject/PlayIdeaPluginMultiprojectIntegrationTest.groovy
@@ -5,6 +5,7 @@ import org.gradle.playframework.application.PlayIdeaPluginIntegrationTest
 import org.gradle.playframework.fixtures.app.PlayApp
 import org.gradle.playframework.fixtures.app.PlayMultiProject
 
+import static org.gradle.api.plugins.JavaPlugin.CLASSES_TASK_NAME
 import static org.gradle.playframework.application.basic.PlayIdeaPluginBasicIntegrationTest.PLAY_VERSION_TO_CLASSPATH_SIZE
 import static org.gradle.playframework.plugins.PlayRoutesPlugin.ROUTES_COMPILE_TASK_NAME
 
@@ -46,6 +47,13 @@ class PlayIdeaPluginMultiprojectIntegrationTest extends PlayIdeaPluginIntegratio
             ":primary:idea",
             ":submodule:ideaModule",
             ":submodule:idea"
+        ]
+    }
+
+    String[] getUnexecutedTasks() {
+        [
+            ":primary:$CLASSES_TASK_NAME".toString(),
+            ":primary:compileScala".toString()
         ]
     }
 

--- a/src/main/java/org/gradle/playframework/plugins/PlayIdeaPlugin.java
+++ b/src/main/java/org/gradle/playframework/plugins/PlayIdeaPlugin.java
@@ -6,7 +6,6 @@ import groovy.xml.QName;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.plugins.DslObject;
@@ -16,6 +15,8 @@ import org.gradle.language.scala.internal.DefaultScalaPlatform;
 import org.gradle.playframework.extensions.PlayExtension;
 import org.gradle.playframework.extensions.PlayPlatform;
 import org.gradle.playframework.tasks.JavaScriptMinify;
+import org.gradle.playframework.tasks.RoutesCompile;
+import org.gradle.playframework.tasks.TwirlCompile;
 import org.gradle.plugins.ide.idea.GenerateIdeaModule;
 import org.gradle.plugins.ide.idea.model.IdeaLanguageLevel;
 import org.gradle.plugins.ide.idea.model.IdeaModule;
@@ -28,7 +29,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
-import static org.gradle.api.plugins.JavaPlugin.CLASSES_TASK_NAME;
 import static org.gradle.playframework.plugins.PlayApplicationPlugin.PLAY_EXTENSION_NAME;
 import static org.gradle.playframework.plugins.internal.PlayPluginHelper.*;
 
@@ -40,8 +40,11 @@ public class PlayIdeaPlugin implements Plugin<Project> {
             IdeaModule module = ideaModuleTask.getModule();
             ConventionMapping conventionMapping = conventionMappingFor(module);
 
-            TaskProvider<Task> classesTask = project.getTasks().named(CLASSES_TASK_NAME);
             TaskProvider<JavaScriptMinify> javaScriptMinifyTask = project.getTasks().named(PlayJavaScriptPlugin.JS_MINIFY_TASK_NAME, JavaScriptMinify.class);
+            TaskProvider<RoutesCompile> routesCompileTask =
+                    project.getTasks().named(PlayRoutesPlugin.ROUTES_COMPILE_TASK_NAME, RoutesCompile.class);
+            TaskProvider<TwirlCompile> twirlCompileTask =
+                    project.getTasks().named(PlayTwirlPlugin.TWIRL_COMPILE_TASK_NAME, TwirlCompile.class);
 
             conventionMapping.map("sourceDirs", (Callable<Set<File>>) () -> {
                 // TODO: Assets should probably be a source set too
@@ -81,8 +84,9 @@ public class PlayIdeaPlugin implements Plugin<Project> {
                 });
             });
 
-            ideaModuleTask.dependsOn(classesTask);
             ideaModuleTask.dependsOn(javaScriptMinifyTask);
+            ideaModuleTask.dependsOn(routesCompileTask);
+            ideaModuleTask.dependsOn(twirlCompileTask);
         });
     }
 


### PR DESCRIPTION
The issue is described in #144 that running `./gradlew idea` will compile all sources. Tests are covered in [PlayIdeaPluginBasicIntegrationTest](https://github.com/gradle/playframework/blob/95e68fe1a90dc40b9ce8b704e1c902369a67490c/src/integTest/groovy/org/gradle/playframework/application/basic/PlayIdeaPluginBasicIntegrationTest.groovy).