### PR TITLE
bump up integration test version to Play 2.7.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ jobs:
       env: GRADLE_TASK=integrationTest PLAY_VERSION=2.5.19
     - name: "Play 2.6.25 Integration Tests"
       env: GRADLE_TASK=integrationTest PLAY_VERSION=2.6.25
-    - name: "Play 2.7.3 Integration Tests"
-      env: GRADLE_TASK=integrationTest PLAY_VERSION=2.7.3
+    - name: "Play 2.7.5 Integration Tests"
+      env: GRADLE_TASK=integrationTest PLAY_VERSION=2.7.5
     - name: "Documentation Tests"
       env: GRADLE_TASK=docTest PLAY_VERSION=not_used
 

--- a/src/docs/asciidoc/00-intro.adoc
+++ b/src/docs/asciidoc/00-intro.adoc
@@ -13,7 +13,7 @@ The Play plugin defines the following requirements for a consuming build.
 
 * The build has to be run with Java 8 or higher.
 * The build has to use Gradle 5.0 or higher.
-* The supported Play versions are 2.4.x, 2.5.x and 2.6.x.
+* The supported Play versions are 2.4.x, 2.5.x, 2.6.x, and 2.7.x.
 
 === Limitations
 

--- a/src/integTestFixtures/groovy/org/gradle/playframework/fixtures/multiversion/PlayCoverage.groovy
+++ b/src/integTestFixtures/groovy/org/gradle/playframework/fixtures/multiversion/PlayCoverage.groovy
@@ -13,7 +13,7 @@ final class PlayCoverage {
             VersionNumber.parse('2.3.10'),
             VersionNumber.parse('2.4.11'),
             VersionNumber.parse('2.5.19'),
-            VersionNumber.parse('2.7.3'),
+            VersionNumber.parse('2.7.5'),
             // Not supported yet
             // VersionNumber.parse('2.8.0'),
             DEFAULT

--- a/src/main/java/org/gradle/playframework/tools/internal/routes/DefaultVersionedRoutesCompilerAdapter.java
+++ b/src/main/java/org/gradle/playframework/tools/internal/routes/DefaultVersionedRoutesCompilerAdapter.java
@@ -18,6 +18,11 @@ abstract class DefaultVersionedRoutesCompilerAdapter implements VersionedRoutesC
 
     @Override
     public String getDependencyNotation() {
+        if (playVersion.equals("2.7.4") || playVersion.equals("2.7.5")) {
+            // this is a hack because of a Play Framework issue
+            // See: https://github.com/playframework/playframework/issues/10333
+            return "com.typesafe.play:routes-compiler_" + scalaVersion + ":2.7.3";
+        }
         return "com.typesafe.play:routes-compiler_" + scalaVersion + ":" + playVersion;
     }
 


### PR DESCRIPTION
This PR hopes to move along the progress on #92
* Bump up integration tests to run with the latest version of Play 2.7.x (2.7.5)
* Minor update to docs to mention 2.7.x support
