### PR TITLE
Replace deprecated usage of Distribution.getBaseName

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,7 +16,7 @@ To engage in the development of the plugin, follow the minimum requirements show
 |==========================
 |Tool    |Minimum Version
 |JDK     |Oracle JDK or OpenJDK 8.x, anything higher won't work with Scala 2.11
-|Gradle  |5.1 or higher
+|Gradle  |6.0 or higher
 |IDE     |IntelliJ 2018.2 or higher
 |==========================
 

--- a/src/docTest/groovy/org/gradle/playframework/InDepthUserGuideSamplesIntegrationTest.groovy
+++ b/src/docTest/groovy/org/gradle/playframework/InDepthUserGuideSamplesIntegrationTest.groovy
@@ -19,7 +19,7 @@ import spock.lang.Unroll
  */
 @Unroll
 class InDepthUserGuideSamplesIntegrationTest extends Specification {
-    private static final String[] VERSIONS_UNDER_TEST = ["5.1.1", "5.2.1", "5.5.1", "5.6.4", "6.0.1", "6.1.1", "6.3"]
+    private static final String[] VERSIONS_UNDER_TEST = ["6.0.1", "6.1.1", "6.3"]
 
     @Rule
     Sample sample = Sample.from("src/docs/samples")

--- a/src/main/java/org/gradle/playframework/plugins/PlayDistributionPlugin.java
+++ b/src/main/java/org/gradle/playframework/plugins/PlayDistributionPlugin.java
@@ -138,7 +138,7 @@ public class PlayDistributionPlugin implements Plugin<Project> {
         final String capitalizedDistName = capitalizeDistributionName(distribution.getName());
         final String stageTaskName = "stage" + capitalizedDistName + "Dist";
         final File stageDir = new File(project.getBuildDir(), "stage");
-        final String baseName = (distribution.getBaseName() != null && "".equals(distribution.getBaseName())) ? distribution.getBaseName() : distribution.getName();
+        final String baseName = (distribution.getDistributionBaseName().isPresent() && "".equals(distribution.getDistributionBaseName().get())) ? distribution.getDistributionBaseName().get() : distribution.getName();
 
         TaskProvider<Sync> stageSyncTask = project.getTasks().register(stageTaskName, Sync.class, sync -> {
             sync.setDescription("Copies the '" + distribution.getName() + "' distribution to a staging directory.");


### PR DESCRIPTION
This code fixes a Gradle 6 warning, see issue #114

**:warning: This breaks compatibility with Gradle 5**