### PR TITLE
Create github action release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8
+
       - name: Publish plugin
         uses: eskatos/gradle-command-action@v1.2.0
         env:
@@ -20,10 +21,35 @@ jobs:
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
         with:
           arguments: publishPlugins -Pgradle.publish.key=${GRADLE_PUBLISH_KEY} -Pgradle.publish.secret=${GRADLE_PUBLISH_SECRET}
+
       - name: Publish Javadocs
         uses: eskatos/gradle-command-action@v1.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           arguments: gitPublishPush -Dorg.ajoberstar.grgit.auth.username=${GITHUB_TOKEN}
+
+      - name: Get release version
+        run: |
+            RELEASE_VERSION=$(./gradlew properties -q | grep 'version:' | awk '{print $2}')
+            [[ ! -z "${RELEASE_VERSION}" ]] || (echo "Get empty release version, RELEASE_VERSION='${RELEASE_VERSION}'" && exit 1)
+            echo "RELEASE_VERSION=${RELEASE_VERSION}" >> ${GITHUB_ENV}
+      - name: Checkout master
+        uses: actions/checkout@v2
+        with:
+          ref: master
+      - name: Modify samples version
+        run: |
+            PLAY_PLUGIN_LINE="id 'org\.gradle\.playframework' version"
+            find src/docs/samples -name 'build.gradle*' -type f -exec sed -i "s/${PLAY_PLUGIN_LINE} '\(.*\)'/${PLAY_PLUGIN_LINE} '${RELEASE_VERSION}'/g" {} +
+        env:
+          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update sample version to ${{ env.RELEASE_VERSION }}
+          branch: master
+          file_pattern: src/docs/samples
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -20,4 +20,10 @@ jobs:
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
         with:
           arguments: publishPlugins -Pgradle.publish.key=${GRADLE_PUBLISH_KEY} -Pgradle.publish.secret=${GRADLE_PUBLISH_SECRET}
+      - name: Publish Javadocs
+        uses: eskatos/gradle-command-action@v1.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          arguments: gitPublishPush -Dorg.ajoberstar.grgit.auth.username=${GITHUB_TOKEN}
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -2,9 +2,6 @@ name: Create Release
 on:
   release:
     types: [created]
-  pull_request:
-    branches:
-      - master
 jobs:
   build:
     name: Create Release

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,26 @@
+name: Create Release
+on:
+  release:
+    types: [created]
+  pull_request:
+    branches:
+      - master
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Publish plugin
+        uses: eskatos/gradle-command-action@v1.2.0
+        env:
+          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+        with:
+          arguments: publishPlugins -Pgradle.publish.key=${GRADLE_PUBLISH_KEY} -Pgradle.publish.secret=${GRADLE_PUBLISH_SECRET}
+

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -17,17 +17,17 @@ jobs:
       - name: Publish plugin
         uses: eskatos/gradle-command-action@v1.2.0
         env:
-          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
-          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+          ORG_GRADLE_PROJECT_gradle.publish.key: ${{ secrets.GRADLE_PUBLISH_KEY }}
+          ORG_GRADLE_PROJECT_gradle.publish.secret: ${{ secrets.GRADLE_PUBLISH_SECRET }}
         with:
-          arguments: publishPlugins -Pgradle.publish.key=${GRADLE_PUBLISH_KEY} -Pgradle.publish.secret=${GRADLE_PUBLISH_SECRET}
+          arguments: publishPlugins
 
       - name: Publish Javadocs
         uses: eskatos/gradle-command-action@v1.2.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GRGIT_USER: ${{ secrets.GITHUB_TOKEN }}
         with:
-          arguments: gitPublishPush -Dorg.ajoberstar.grgit.auth.username=${GITHUB_TOKEN}
+          arguments: gitPublishPush
 
       - name: Get release version
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ out
 .project
 .settings
 */bin/
+*.swp

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     org.gradle.playframework.`user-guide`
     org.gradle.playframework.`github-pages`
     org.gradle.playframework.`documentation-test`
-    id("com.gradle.plugin-publish") version "0.10.1"
+    id("com.gradle.plugin-publish") version "0.12.0"
 }
 
 group = "org.gradle.playframework"


### PR DESCRIPTION
Create a release workflow which automates the release 3, 4, 5 step mentioned in [README](https://github.com/gradle/playframework#release).
```
3. Build the binary artifact and publish it to the Gradle Plugin Portal by running the task publishPlugins.

4. Build and publish the Javadocs and the user guide by running the task gitPublishPush.

5. Manually update the plugin version for all samples in the directory src/docs/samples. Commit and push the changes to GitHub.
```
Once we verify these steps successfully replaced by this release workflow, we can modify the step in README.

### Testing
Tested machine commit on my forked repo by creating a release
1. The [executed job](https://github.com/JospehChiu/playframework/runs/1243491648?check_suite_focus=true)
2. the machine commit https://github.com/JospehChiu/playframework/commit/944338e3b9bd05ec89e6bfdd45d147b2082b136f

Without specific `commit_user_name` `commit_user_email` `commit_author`, the commit author will be the one creates release, the commiter will be action-users.