### PR TITLE
Add Play 2.8.x compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ jobs:
       env: GRADLE_TASK=integrationTest PLAY_VERSION=2.6.25
     - name: "Play 2.7.5 Integration Tests"
       env: GRADLE_TASK=integrationTest PLAY_VERSION=2.7.5
+    - name: "Play 2.8.2 Integration Tests"
+      env: GRADLE_TASK=integrationTest PLAY_VERSION=2.8.2
     - name: "Documentation Tests"
       env: GRADLE_TASK=docTest PLAY_VERSION=not_used
 

--- a/src/docs/asciidoc/00-intro.adoc
+++ b/src/docs/asciidoc/00-intro.adoc
@@ -13,7 +13,7 @@ The Play plugin defines the following requirements for a consuming build.
 
 * The build has to be run with Java 8 or higher.
 * The build has to use Gradle 5.0 or higher.
-* The supported Play versions are 2.4.x, 2.5.x, 2.6.x, and 2.7.x.
+* The supported Play versions are 2.4.x, 2.5.x, 2.6.x, 2.7.x, and 2.8.x.
 
 === Limitations
 

--- a/src/docs/asciidoc/11-play-framework.adoc
+++ b/src/docs/asciidoc/11-play-framework.adoc
@@ -9,6 +9,10 @@ The following versions of Play and Scala are supported:
 |===
 | Play | Scala | Java
 
+| 2.8.x
+| 2.12 and 2.13
+| 1.8
+
 | 2.7.x
 | 2.11, 2.12 and 2.13
 | 1.8

--- a/src/integTestFixtures/groovy/org/gradle/playframework/fixtures/multiversion/PlayCoverage.groovy
+++ b/src/integTestFixtures/groovy/org/gradle/playframework/fixtures/multiversion/PlayCoverage.groovy
@@ -14,8 +14,7 @@ final class PlayCoverage {
             VersionNumber.parse('2.4.11'),
             VersionNumber.parse('2.5.19'),
             VersionNumber.parse('2.7.5'),
-            // Not supported yet
-            // VersionNumber.parse('2.8.0'),
+            VersionNumber.parse('2.8.0'),
             DEFAULT
     ]
 }

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/advancedplayapp/app/controllers/Application.scala.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/advancedplayapp/app/controllers/Application.scala.ftl
@@ -16,7 +16,7 @@
 
 package controllers
 
-<#if playVersion == "2.7" || playVersion == "2.6">
+<#if playVersion == "2.8" || playVersion == "2.7" || playVersion == "2.6">
 import javax.inject._
 import play.api._
 import play.api.mvc._

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/advancedplayapp/app/controllers/jva/PureJava.java.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/advancedplayapp/app/controllers/jva/PureJava.java.ftl
@@ -21,7 +21,7 @@ import jva.html.*;
 
 public class PureJava extends Controller {
 
-<#if playVersion == "2.7">
+<#if playVersion == "2.8" || playVersion == "2.7">
     public Result index() {
 <#else>
     public static Result index() {

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/advancedplayapp/app/controllers/scla/MixedJava.java.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/advancedplayapp/app/controllers/scla/MixedJava.java.ftl
@@ -22,7 +22,7 @@ import views.html.*;
 
 public class MixedJava extends Controller {
 
-<#if playVersion == "2.7">
+<#if playVersion == "2.8" || playVersion == "2.7">
     public Result index() {
 <#else>
     public static Result index() {

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/advancedplayapp/app/special/strangename/Application.scala.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/advancedplayapp/app/special/strangename/Application.scala.ftl
@@ -16,7 +16,7 @@
 
 package special.strangename
 
-<#if playVersion == "2.7" || playVersion == "2.6">
+<#if playVersion == "2.8" || playVersion == "2.7" || playVersion == "2.6">
 import javax.inject._
 import play.api._
 import play.api.mvc._

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/advancedplayapp/build.gradle.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/advancedplayapp/build.gradle.ftl
@@ -14,7 +14,7 @@ sourceSets {
     }
 }
 
-<#if playVersion == "2.7" || playVersion == "2.6">
+<#if playVersion == "2.8" || playVersion == "2.7" || playVersion == "2.6">
 dependencies {
     implementation "com.typesafe.play:play-guice_2.12:2.6.15"
     implementation "ch.qos.logback:logback-classic:1.2.3"

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/advancedplayapp/conf/routes.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/advancedplayapp/conf/routes.ftl
@@ -1,4 +1,4 @@
-<#if playVersion == "2.7" || playVersion == "2.6">
+<#if playVersion == "2.8" || playVersion == "2.7" || playVersion == "2.6">
 # Routes
 GET /          @controllers.Application.index
 GET /root      @controllers.Application.root

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/advancedplayapp/conf/scala.routes.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/advancedplayapp/conf/scala.routes.ftl
@@ -1,4 +1,4 @@
-<#if playVersion == "2.7" || playVersion == "2.6">
+<#if playVersion == "2.8" || playVersion == "2.7" || playVersion == "2.6">
 GET        /one         controllers.scla.MixedJava.index
 POST       /two         @special.strangename.Application.index
 

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/basicplayapp/app/controllers/Application.scala.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/basicplayapp/app/controllers/Application.scala.ftl
@@ -16,7 +16,7 @@
 
 package controllers
 
-<#if playVersion == "2.7" || playVersion == "2.6">
+<#if playVersion == "2.8" || playVersion == "2.7" || playVersion == "2.6">
 import javax.inject._
 import play.api._
 import play.api.mvc._

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/basicplayapp/build.gradle.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/basicplayapp/build.gradle.ftl
@@ -1,4 +1,4 @@
-<#if playVersion == "2.7" || playVersion == "2.6">
+<#if playVersion == "2.8" || playVersion == "2.7" || playVersion == "2.6">
 plugins {
     id 'org.gradle.playframework'
 }

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/basicplayapp/conf/routes.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/basicplayapp/conf/routes.ftl
@@ -1,4 +1,4 @@
-<#if playVersion == "2.7" || playVersion == "2.6">
+<#if playVersion == "2.8" || playVersion == "2.7" || playVersion == "2.6">
 # Routes
 # Home page
 GET     /                           @controllers.Application.index

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playappwithdependencies/app/controllers/Application.scala.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playappwithdependencies/app/controllers/Application.scala.ftl
@@ -16,7 +16,7 @@
 
 package controllers
 
-<#if playVersion == "2.7" || playVersion == "2.6">
+<#if playVersion == "2.8" || playVersion == "2.7" || playVersion == "2.6">
 import javax.inject._
 import com.google.common.base.Strings
 import play.api._

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playappwithdependencies/build.gradle.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playappwithdependencies/build.gradle.ftl
@@ -1,4 +1,4 @@
-<#if playVersion == "2.7" || playVersion == "2.6">
+<#if playVersion == "2.8" || playVersion == "2.7" || playVersion == "2.6">
 plugins {
     id 'org.gradle.playframework'
 }

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playappwithdependencies/conf/routes.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playappwithdependencies/conf/routes.ftl
@@ -1,4 +1,4 @@
-<#if playVersion == "2.7" || playVersion == "2.6">
+<#if playVersion == "2.8" || playVersion == "2.7" || playVersion == "2.6">
 # Routes
 # Home page
 GET     /                           @controllers.Application.index

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playcompositebuild/app/controllers/Application.scala.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playcompositebuild/app/controllers/Application.scala.ftl
@@ -1,6 +1,6 @@
 package controllers
 
-<#if playVersion == "2.7" || playVersion == "2.6">
+<#if playVersion == "2.8" || playVersion == "2.7" || playVersion == "2.6">
 import javax.inject._
 import play.api._
 import play.api.mvc._

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playcompositebuild/build.gradle.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playcompositebuild/build.gradle.ftl
@@ -1,4 +1,4 @@
-<#if playVersion == "2.7" || playVersion == "2.6">
+<#if playVersion == "2.8" || playVersion == "2.7" || playVersion == "2.6">
 plugins {
     id 'org.gradle.playframework'
 }

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playcompositebuild/conf/routes.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playcompositebuild/conf/routes.ftl
@@ -1,4 +1,4 @@
-<#if playVersion == "2.7" || playVersion == "2.6">
+<#if playVersion == "2.8" || playVersion == "2.7" || playVersion == "2.6">
 GET     /                          @controllers.Application.index
 GET     /shutdown                  @controllers.Application.shutdown
 GET     /assets/*file              @controllers.Assets.at(path="/public", file)

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playmultiproject/build.gradle.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playmultiproject/build.gradle.ftl
@@ -1,4 +1,4 @@
-<#if playVersion == "2.7" || playVersion == "2.6">
+<#if playVersion == "2.8" || playVersion == "2.7" || playVersion == "2.6">
 plugins {
     id 'org.gradle.playframework'
 }

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playmultiproject/primary/app/controllers/Application.scala.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playmultiproject/primary/app/controllers/Application.scala.ftl
@@ -1,6 +1,6 @@
 package controllers
 
-<#if playVersion == "2.7" || playVersion == "2.6">
+<#if playVersion == "2.8" || playVersion == "2.7" || playVersion == "2.6">
 import javax.inject._
 import play.api._
 import play.api.mvc._

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playmultiproject/primary/build.gradle.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playmultiproject/primary/build.gradle.ftl
@@ -1,4 +1,4 @@
-<#if playVersion == "2.7" || playVersion == "2.6">
+<#if playVersion == "2.8" || playVersion == "2.7" || playVersion == "2.6">
 plugins {
     id 'org.gradle.playframework'
 }

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playmultiproject/primary/conf/application.conf.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playmultiproject/primary/conf/application.conf.ftl
@@ -1,4 +1,4 @@
-<#if playVersion == "2.7" || playVersion == "2.6">
+<#if playVersion == "2.8" || playVersion == "2.7" || playVersion == "2.6">
 # https://www.playframework.com/documentation/2.6.x/ApplicationSecret
 play.http.secret.key="somethingsecret"
 

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playmultiproject/primary/conf/routes.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playmultiproject/primary/conf/routes.ftl
@@ -1,4 +1,4 @@
-<#if playVersion == "2.7" || playVersion == "2.6">
+<#if playVersion == "2.8" || playVersion == "2.7" || playVersion == "2.6">
 GET     /                          @controllers.Application.index
 GET     /shutdown                  @controllers.Application.shutdown
 GET     /submodule                 @controllers.submodule.Application.index

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playmultiproject/submodule/app/controllers/submodule/Application.scala.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playmultiproject/submodule/app/controllers/submodule/Application.scala.ftl
@@ -1,6 +1,6 @@
 package controllers.submodule
 
-<#if playVersion == "2.7" || playVersion == "2.6">
+<#if playVersion == "2.8" || playVersion == "2.7" || playVersion == "2.6">
 import javax.inject._
 import play.api._
 import play.api.mvc._

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playmultiproject/submodule/build.gradle.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playmultiproject/submodule/build.gradle.ftl
@@ -1,4 +1,4 @@
-<#if playVersion == "2.7" || playVersion == "2.6">
+<#if playVersion == "2.8" || playVersion == "2.7" || playVersion == "2.6">
 plugins {
     id 'org.gradle.playframework'
 }

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/shared/conf/application.conf.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/shared/conf/application.conf.ftl
@@ -1,4 +1,4 @@
-<#if playVersion == "2.7" || playVersion == "2.6">
+<#if playVersion == "2.8" || playVersion == "2.7" || playVersion == "2.6">
 play.http.secret.key="TY9[b`xw2MeXUt;M<i_B0kUKm8/?PD1cS1WhFYyZ[1^6`Apew34q6DyNL=UqG/1l"
 
 <#else>

--- a/src/main/java/org/gradle/playframework/extensions/internal/PlayMajorVersion.java
+++ b/src/main/java/org/gradle/playframework/extensions/internal/PlayMajorVersion.java
@@ -13,9 +13,8 @@ public enum PlayMajorVersion {
     PLAY_2_4_X("2.4.x", true, "2.11", "2.10"),
     PLAY_2_5_X("2.5.x", true,"2.11"),
     PLAY_2_6_X("2.6.x", true, "2.12", "2.11"),
-    PLAY_2_7_X("2.7.x", false, "2.13", "2.12", "2.11");
-    // Not supported yet
-    // PLAY_2_8_X("2.8.x", false, "2.13", "2.12");
+    PLAY_2_7_X("2.7.x", false, "2.13", "2.12", "2.11"),
+    PLAY_2_8_X("2.8.x", false, "2.13", "2.12");
 
     private final String name;
     private final boolean supportForStaticRoutes;

--- a/src/main/java/org/gradle/playframework/tools/internal/routes/RoutesCompilerFactory.java
+++ b/src/main/java/org/gradle/playframework/tools/internal/routes/RoutesCompilerFactory.java
@@ -24,6 +24,7 @@ public class RoutesCompilerFactory {
             case PLAY_2_6_X:
                 return new RoutesCompilerAdapterV24X(playVersion, scalaVersion);
             case PLAY_2_7_X:
+            case PLAY_2_8_X:
             default:
                 return new RoutesCompilerAdapterV27X(playVersion, scalaVersion);
         }


### PR DESCRIPTION
Continuing on from #133 except as requested, makes the necessary changes to have the integration tests actually run for Play 2.8.0.

According to Play's changelog, [2.8.0 did not introduce a great many changes](https://www.playframework.com/documentation/2.8.x/Migration28), except dropping Scala 2.11 support.

Edit: Looks like the java template fails integration tests, so I'll go through to try and update the template accordingly.