### PR TITLE
Make playframework plugin compatible with Gradle 7.x

### DIFF
--- a/src/integTest/groovy/org/gradle/playframework/application/advanced/PlayIdeaPluginAdvancedIntegrationTest.groovy
+++ b/src/integTest/groovy/org/gradle/playframework/application/advanced/PlayIdeaPluginAdvancedIntegrationTest.groovy
@@ -1,7 +1,7 @@
 package org.gradle.playframework.application.advanced
 
-import org.gradle.play.internal.platform.PlayMajorVersion
 import org.gradle.playframework.application.PlayIdeaPluginIntegrationTest
+import org.gradle.playframework.extensions.internal.PlayMajorVersion
 import org.gradle.playframework.fixtures.app.AdvancedPlayApp
 import org.gradle.playframework.fixtures.app.PlayApp
 

--- a/src/integTest/groovy/org/gradle/playframework/application/basic/PlayIdeaPluginBasicIntegrationTest.groovy
+++ b/src/integTest/groovy/org/gradle/playframework/application/basic/PlayIdeaPluginBasicIntegrationTest.groovy
@@ -1,7 +1,7 @@
 package org.gradle.playframework.application.basic
 
-import org.gradle.play.internal.platform.PlayMajorVersion
 import org.gradle.playframework.application.PlayIdeaPluginIntegrationTest
+import org.gradle.playframework.extensions.internal.PlayMajorVersion
 import org.gradle.playframework.fixtures.app.BasicPlayApp
 import org.gradle.playframework.fixtures.app.PlayApp
 import org.gradle.testkit.runner.BuildResult

--- a/src/integTest/groovy/org/gradle/playframework/application/multiproject/PlayIdeaPluginMultiprojectIntegrationTest.groovy
+++ b/src/integTest/groovy/org/gradle/playframework/application/multiproject/PlayIdeaPluginMultiprojectIntegrationTest.groovy
@@ -1,7 +1,7 @@
 package org.gradle.playframework.application.multiproject
 
-import org.gradle.play.internal.platform.PlayMajorVersion
 import org.gradle.playframework.application.PlayIdeaPluginIntegrationTest
+import org.gradle.playframework.extensions.internal.PlayMajorVersion
 import org.gradle.playframework.fixtures.app.PlayApp
 import org.gradle.playframework.fixtures.app.PlayMultiProject
 

--- a/src/main/java/org/gradle/playframework/plugins/PlayDistributionPlugin.java
+++ b/src/main/java/org/gradle/playframework/plugins/PlayDistributionPlugin.java
@@ -182,7 +182,8 @@ public class PlayDistributionPlugin implements Plugin<Project> {
             return providers.provider(new Callable<String>() {
                 @Override
                 public String call() throws Exception {
-                    return (distribution.getBaseName() != null && "".equals(distribution.getBaseName())) ? distribution.getBaseName() : distribution.getName();
+                    String baseName = (String) Distribution.class.getMethod("getBaseName").invoke(distribution);
+                    return "".equals(baseName) ? "" : distribution.getName();
                 }
             });
         } else {

--- a/src/main/java/org/gradle/playframework/tasks/PlayRun.java
+++ b/src/main/java/org/gradle/playframework/tasks/PlayRun.java
@@ -3,6 +3,7 @@ package org.gradle.playframework.tasks;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.playframework.extensions.PlayPlatform;
 import org.gradle.playframework.tools.internal.run.DefaultPlayRunSpec;
@@ -69,7 +70,7 @@ public class PlayRun extends DefaultTask {
 
         if (deploymentHandle == null) {
             PlayRunSpec spec = new DefaultPlayRunSpec(runtimeClasspath, changingClasspath, applicationJar.getAsFile().get(), assetsJar.getAsFile().get(), assetsDirs, workingDir.get().getAsFile(), getForkOptions(), getHttpPort().get());
-            PlayApplicationRunner playApplicationRunner = PlayApplicationRunnerFactory.create(platform.get(), getWorkerProcessFactory(), getClasspathFingerprinter());
+            PlayApplicationRunner playApplicationRunner = PlayApplicationRunnerFactory.create(platform.get(), getWorkerProcessFactory(), getClasspathFingerprinter(), getFileCollectionFactory());
             deploymentHandle = deploymentRegistry.start(deploymentId, DeploymentRegistry.ChangeBehavior.BLOCK, PlayApplicationDeploymentHandle.class, spec, playApplicationRunner);
 
             InetSocketAddress playAppAddress = deploymentHandle.getPlayAppAddress();
@@ -178,6 +179,11 @@ public class PlayRun extends DefaultTask {
 
     @Inject
     public ClasspathFingerprinter getClasspathFingerprinter() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Inject
+    public FileCollectionFactory getFileCollectionFactory() {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/org/gradle/playframework/tools/internal/javascript/GoogleClosureCompiler.java
+++ b/src/main/java/org/gradle/playframework/tools/internal/javascript/GoogleClosureCompiler.java
@@ -1,5 +1,6 @@
 package org.gradle.playframework.tools.internal.javascript;
 
+import org.gradle.api.GradleException;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.internal.file.RelativeFile;
 import org.gradle.api.tasks.WorkResult;
@@ -9,7 +10,6 @@ import org.gradle.playframework.tools.internal.reflection.DirectInstantiator;
 import org.gradle.playframework.tools.internal.reflection.JavaMethod;
 import org.gradle.playframework.tools.internal.reflection.JavaReflectionUtil;
 import org.gradle.playframework.tools.internal.reflection.PropertyAccessor;
-import org.gradle.plugins.javascript.base.SourceTransformationException;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,7 +49,7 @@ public class GoogleClosureCompiler implements Compiler<JavaScriptCompileSpec>, S
         if (allErrors.isEmpty()) {
             return WorkResults.didWork(true);
         } else {
-            throw new SourceTransformationException(String.format("Minification failed with the following errors:\n\t%s", String.join( "\n\t", allErrors)), null);
+            throw new GradleException(String.format("Minification failed with the following errors:\n\t%s", String.join( "\n\t", allErrors)), null);
         }
     }
 

--- a/src/main/java/org/gradle/playframework/tools/internal/javascript/GoogleClosureCompiler.java
+++ b/src/main/java/org/gradle/playframework/tools/internal/javascript/GoogleClosureCompiler.java
@@ -49,7 +49,7 @@ public class GoogleClosureCompiler implements Compiler<JavaScriptCompileSpec>, S
         if (allErrors.isEmpty()) {
             return WorkResults.didWork(true);
         } else {
-            throw new GradleException(String.format("Minification failed with the following errors:\n\t%s", String.join( "\n\t", allErrors)), null);
+            throw new GradleException(String.format("Minification failed with the following errors:\n\t%s", String.join( "\n\t", allErrors)));
         }
     }
 

--- a/src/main/java/org/gradle/playframework/tools/internal/run/PlayApplicationRunnerFactory.java
+++ b/src/main/java/org/gradle/playframework/tools/internal/run/PlayApplicationRunnerFactory.java
@@ -1,13 +1,14 @@
 package org.gradle.playframework.tools.internal.run;
 
+import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.playframework.extensions.PlayPlatform;
 import org.gradle.playframework.extensions.internal.PlayMajorVersion;
 import org.gradle.internal.fingerprint.classpath.ClasspathFingerprinter;
 import org.gradle.process.internal.worker.WorkerProcessFactory;
 
 public class PlayApplicationRunnerFactory {
-    public static PlayApplicationRunner create(PlayPlatform playPlatform, WorkerProcessFactory workerFactory, ClasspathFingerprinter fingerprinter) {
-        return new PlayApplicationRunner(workerFactory, createPlayRunAdapter(playPlatform), fingerprinter);
+    public static PlayApplicationRunner create(PlayPlatform playPlatform, WorkerProcessFactory workerFactory, ClasspathFingerprinter fingerprinter, FileCollectionFactory fileCollectionFactory) {
+        return new PlayApplicationRunner(workerFactory, createPlayRunAdapter(playPlatform), fingerprinter, fileCollectionFactory);
     }
 
     public static VersionedPlayRunAdapter createPlayRunAdapter(PlayPlatform playPlatform) {


### PR DESCRIPTION
This fixes things in the plugin to make it work with Gradle 7.x:
- The plugin accidentally used `org.gradle.plugins.javascript.base.SourceTransformationException`, which is no longer available in Gradle 7
- Integration tests accidentally used `org.gradle.playframework.extensions.internal.PlayMajorVersion`, which is no longer available in Gradle 7
- `Distribution.getBaseName()` is no longer available, so we now use reflection to access that method in Gradle 5.x
- No longer use `ImmutableFileCollection.of()`

