### PR TITLE
Remove JCenter as it is going away

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ group = "org.gradle.playframework"
 version = "0.11"
 
 repositories {
-    jcenter()
+    mavenCentral()
     maven(url = "https://repo.gradle.org/gradle/libs")
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,7 +4,8 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
+    maven("https://plugins.gradle.org/m2/")
 }
 
 dependencies {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/docs/samples/advanced/groovy/build.gradle
+++ b/src/docs/samples/advanced/groovy/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 // end::play-dependencies[]
 
 repositories {
-    jcenter()
+    mavenCentral()
     maven {
         name "lightbend-maven-release"
         url "https://repo.lightbend.com/lightbend/maven-releases"

--- a/src/docs/samples/basic/groovy/build.gradle
+++ b/src/docs/samples/basic/groovy/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
     maven {
         name "lightbend-maven-release"
         url "https://repo.lightbend.com/lightbend/maven-releases"

--- a/src/docs/samples/configure-compiler/groovy/build.gradle
+++ b/src/docs/samples/configure-compiler/groovy/build.gradle
@@ -6,7 +6,7 @@ plugins {
 // end::plugin-definition[]
 
 repositories {
-    jcenter()
+    mavenCentral()
     maven {
         name "lightbend-maven-release"
         url "https://repo.lightbend.com/lightbend/maven-releases"

--- a/src/docs/samples/custom-distribution/groovy/build.gradle
+++ b/src/docs/samples/custom-distribution/groovy/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
     maven {
         name "lightbend-maven-release"
         url "https://repo.lightbend.com/lightbend/maven-releases"

--- a/src/docs/samples/multi-project/groovy/build.gradle
+++ b/src/docs/samples/multi-project/groovy/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             name "lightbend-maven-release"
             url "https://repo.lightbend.com/lightbend/maven-releases"

--- a/src/docs/samples/play-2.4/groovy/build.gradle
+++ b/src/docs/samples/play-2.4/groovy/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
     maven {
         name "lightbend-maven-release"
         url "https://repo.lightbend.com/lightbend/maven-releases"

--- a/src/docs/samples/play-2.6/groovy/build.gradle
+++ b/src/docs/samples/play-2.6/groovy/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
     maven {
         name "lightbend-maven-releases"
         url "https://repo.lightbend.com/lightbend/maven-release"

--- a/src/docs/samples/play-platform/groovy/build.gradle
+++ b/src/docs/samples/play-platform/groovy/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
     maven {
         name "lightbend-maven-release"
         url "https://repo.lightbend.com/lightbend/maven-releases"

--- a/src/docs/samples/source-sets/groovy/build.gradle
+++ b/src/docs/samples/source-sets/groovy/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
     maven {
         name "lightbend-maven-release"
         url "https://repo.lightbend.com/lightbend/maven-releases"

--- a/src/integTestFixtures/groovy/org/gradle/playframework/fixtures/Repositories.groovy
+++ b/src/integTestFixtures/groovy/org/gradle/playframework/fixtures/Repositories.groovy
@@ -7,7 +7,7 @@ final class Repositories {
     static String playRepositories() {
         """
             repositories {
-                jcenter()
+                mavenCentral()
                 maven {
                     name "lightbend-maven-release"
                     url "https://repo.lightbend.com/lightbend/maven-releases"


### PR DESCRIPTION
Replace JCenter references with Maven Central

See https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/