### PR TITLE
Add property to configure dependencies prefixing

### DIFF
--- a/src/docs/asciidoc/30-plugin-configuration.adoc
+++ b/src/docs/asciidoc/30-plugin-configuration.adoc
@@ -9,3 +9,5 @@ include::33-add-source-directories.adoc[]
 include::34-compiler-options.adoc[]
 
 include::35-add-distribution-files.adoc[]
+
+include::36-prefixing-dependencies.adoc[]

--- a/src/docs/asciidoc/36-prefixing-dependencies.adoc
+++ b/src/docs/asciidoc/36-prefixing-dependencies.adoc
@@ -1,0 +1,14 @@
+=== Prefixing dependencies
+
+By default, your project's distribution task will prefix all your dependencies as follows:
+
+* Each jar will be prefixed with the library's group name - e.g. `com.typesafe.play-play_2.12-2.6.25.jar`
+* Each sub-module's jar, in a multi-module project, will be prefixed with the module's name
+
+The default behavior can be turned off using the `prefixDependencies` configuration.
+
+[source,groovy]
+.build.gradle
+----
+include::{samplesCodeDir}/play-2.4/groovy/build.gradle[tag=prefix-dependencies-off]
+----

--- a/src/docs/samples/play-2.4/groovy/build.gradle
+++ b/src/docs/samples/play-2.4/groovy/build.gradle
@@ -33,3 +33,9 @@ play {
     injectedRoutesGenerator = true
 }
 // end::injected-routes-compiler[]
+
+// tag::prefix-dependencies-off[]
+play {
+    prefixDependencies = false
+}
+// end::prefix-dependencies-off[]

--- a/src/integTest/groovy/org/gradle/playframework/application/PlayDistributionApplicationIntegrationTest.groovy
+++ b/src/integTest/groovy/org/gradle/playframework/application/PlayDistributionApplicationIntegrationTest.groovy
@@ -2,12 +2,9 @@ package org.gradle.playframework.application
 
 import org.gradle.playframework.PlayMultiVersionApplicationIntegrationTest
 import org.gradle.playframework.fixtures.archive.ArchiveTestFixture
-import org.gradle.playframework.fixtures.archive.JarTestFixture
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.util.VersionNumber
-
-import java.util.jar.Attributes
 
 import static org.gradle.playframework.plugins.PlayApplicationPlugin.ASSETS_JAR_TASK_NAME
 import static org.gradle.playframework.plugins.PlayRoutesPlugin.ROUTES_COMPILE_TASK_NAME
@@ -38,6 +35,7 @@ abstract class PlayDistributionApplicationIntegrationTest extends PlayMultiVersi
         and:
         verifyJars()
         verifyStagedFiles()
+        verifyDependenciesPrefix()
 
         when:
         result = build("dist")
@@ -56,6 +54,7 @@ abstract class PlayDistributionApplicationIntegrationTest extends PlayMultiVersi
     List<ArchiveTestFixture> archives() {
         [ zip("build/distributions/main.zip"), tar("build/distributions/main.tar") ]
     }
+
     void verifyArchives() {
         archives()*.containsDescendants(
                 "main/lib/${playApp.name}.jar",
@@ -64,6 +63,15 @@ abstract class PlayDistributionApplicationIntegrationTest extends PlayMultiVersi
                 "main/bin/main.bat",
                 "main/conf/application.conf",
                 "main/README")
+    }
+
+    protected boolean shouldPrefixDependencies() {
+        return true
+    }
+
+    final void verifyDependenciesPrefix() {
+        def dependencies = file("build/stage/main/lib/").listFiles().collect { it.name }
+        assert dependencies.any { it.startsWith("com.typesafe.play-play_") } == shouldPrefixDependencies()
     }
 
     void verifyStagedFiles() {

--- a/src/integTest/groovy/org/gradle/playframework/application/dependencies/PlayDistributionAppWithDependenciesNoPrefixIntegrationTest.groovy
+++ b/src/integTest/groovy/org/gradle/playframework/application/dependencies/PlayDistributionAppWithDependenciesNoPrefixIntegrationTest.groovy
@@ -1,0 +1,18 @@
+package org.gradle.playframework.application.dependencies
+
+import org.gradle.playframework.application.PlayDistributionApplicationIntegrationTest
+import org.gradle.playframework.fixtures.app.PlayApp
+import org.gradle.playframework.fixtures.app.PlayAppWithDependenciesNoPrefix
+
+class PlayDistributionAppWithDependenciesNoPrefixIntegrationTest extends PlayDistributionApplicationIntegrationTest {
+
+    @Override
+    PlayApp getPlayApp() {
+        new PlayAppWithDependenciesNoPrefix(playVersion)
+    }
+
+    @Override
+    protected boolean shouldPrefixDependencies() {
+        return false
+    }
+}

--- a/src/integTestFixtures/groovy/org/gradle/playframework/fixtures/Repositories.groovy
+++ b/src/integTestFixtures/groovy/org/gradle/playframework/fixtures/Repositories.groovy
@@ -8,11 +8,6 @@ final class Repositories {
         """
             repositories {
                 mavenCentral()
-                // TODO Remove once lightbend migrates everything to repo.lightbend.com
-                maven {
-                    name "lightbend-bintray-releases"
-                    url "https://dl.bintray.com/typesafe/maven-releases"
-                }
                 maven {
                     name "lightbend-maven-release"
                     url "https://repo.lightbend.com/lightbend/maven-releases"

--- a/src/integTestFixtures/groovy/org/gradle/playframework/fixtures/Repositories.groovy
+++ b/src/integTestFixtures/groovy/org/gradle/playframework/fixtures/Repositories.groovy
@@ -8,6 +8,11 @@ final class Repositories {
         """
             repositories {
                 mavenCentral()
+                // TODO Remove once lightbend migrates everything to repo.lightbend.com
+                maven {
+                    name "lightbend-bintray-releases"
+                    url "https://dl.bintray.com/typesafe/maven-releases"
+                }
                 maven {
                     name "lightbend-maven-release"
                     url "https://repo.lightbend.com/lightbend/maven-releases"

--- a/src/integTestFixtures/groovy/org/gradle/playframework/fixtures/app/PlayAppWithDependenciesNoPrefix.groovy
+++ b/src/integTestFixtures/groovy/org/gradle/playframework/fixtures/app/PlayAppWithDependenciesNoPrefix.groovy
@@ -1,0 +1,9 @@
+package org.gradle.playframework.fixtures.app
+
+import org.gradle.util.VersionNumber
+
+class PlayAppWithDependenciesNoPrefix extends PlayApp {
+    PlayAppWithDependenciesNoPrefix(VersionNumber version) {
+        super(version)
+    }
+}

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playappwithdependenciesnoprefix/app/controllers/Application.scala.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playappwithdependenciesnoprefix/app/controllers/Application.scala.ftl
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+<#if playVersion == "2.8" || playVersion == "2.7" || playVersion == "2.6">
+import javax.inject._
+import com.google.common.base.Strings
+import play.api._
+import play.api.mvc._
+
+@Singleton
+class Application @Inject() extends InjectedController {
+
+  def index = Action {
+    Ok(views.html.index(Strings.nullToEmpty("Your new application is ready.")))
+  }
+
+  def shutdown = Action {
+    Runtime.getRuntime().halt(0)
+    Ok("shutdown")
+  }
+}
+<#else>
+import com.google.common.base.Strings
+import play.api._
+import play.api.mvc._
+
+object Application extends Controller {
+
+  def index = Action {
+    Ok(views.html.index(Strings.nullToEmpty("Your new application is ready.")))
+  }
+
+  def shutdown = Action {
+    System.exit(0)
+    Ok("shutdown")
+  }
+}
+</#if>

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playappwithdependenciesnoprefix/app/views/index.scala.html
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playappwithdependenciesnoprefix/app/views/index.scala.html
@@ -1,0 +1,7 @@
+@(message: String)
+
+@main("Welcome to Play") {
+
+    <h1>@message</h1>
+
+}

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playappwithdependenciesnoprefix/app/views/main.scala.html
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playappwithdependenciesnoprefix/app/views/main.scala.html
@@ -1,0 +1,13 @@
+@(title: String)(content: Html)
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>@title</title>
+        <link rel="stylesheet" media="screen" href="@routes.Assets.at("stylesheets/main.css")">
+        <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/favicon.png")">
+        <script src="@routes.Assets.at("javascripts/hello.js")" type="text/javascript"></script>
+    </head>
+    <body>
+@content
+    </body>
+</html>

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playappwithdependenciesnoprefix/build.gradle.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playappwithdependenciesnoprefix/build.gradle.ftl
@@ -1,0 +1,35 @@
+<#if playVersion == "2.8" || playVersion == "2.7" || playVersion == "2.6">
+plugins {
+    id 'org.gradle.playframework'
+}
+
+dependencies {
+    implementation "com.google.guava:guava:17.0"
+    implementation "com.typesafe.play:play-guice_2.12:2.6.15"
+    implementation "ch.qos.logback:logback-classic:1.2.3"
+    testImplementation "commons-lang:commons-lang:2.6"
+}
+
+play {
+    prefixDependencies = false
+}
+
+// repositories added in PlayApp class
+
+<#else>
+plugins {
+    id 'org.gradle.playframework'
+}
+
+dependencies {
+    implementation "com.google.guava:guava:17.0"
+    testImplementation "commons-lang:commons-lang:2.6"
+}
+
+// repositories added in PlayApp class
+
+play {
+    prefixDependencies = false
+}
+
+</#if>

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playappwithdependenciesnoprefix/conf/routes.ftl
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playappwithdependenciesnoprefix/conf/routes.ftl
@@ -1,0 +1,21 @@
+<#if playVersion == "2.8" || playVersion == "2.7" || playVersion == "2.6">
+# Routes
+# Home page
+GET     /                           @controllers.Application.index
+
+GET     /shutdown                   @controllers.Application.shutdown
+
+# Map static resources from the /public folder to the /assets URL path
+GET     /assets/*file               @controllers.Assets.at(path="/public", file)
+
+<#else>
+# Routes
+# Home page
+GET     /                           controllers.Application.index
+
+GET     /shutdown                   controllers.Application.shutdown
+
+# Map static resources from the /public folder to the /assets URL path
+GET     /assets/*file               controllers.Assets.at(path="/public", file)
+
+</#if>

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playappwithdependenciesnoprefix/test/ApplicationSpec.scala
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playappwithdependenciesnoprefix/test/ApplicationSpec.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.junit._
+
+class ApplicationSpec  {
+  @Test 
+  def passingTest() {
+  }
+  @Test 
+  def passingTest2() {
+  }
+}

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playappwithdependenciesnoprefix/test/IntegrationSpec.scala
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playappwithdependenciesnoprefix/test/IntegrationSpec.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.junit._
+
+class IntegrationSpec  {
+  @Test 
+  def passingTest() {
+  }
+}

--- a/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playappwithdependenciesnoprefix/test/notATest.yaml
+++ b/src/integTestFixtures/resources/org/gradle/playframework/fixtures/app/playappwithdependenciesnoprefix/test/notATest.yaml
@@ -1,0 +1,7 @@
+name: Test
+number: 1234
+items:
+    - name: item1
+      description: first item
+    - name: item2
+      description: second item

--- a/src/main/java/org/gradle/playframework/extensions/PlayExtension.java
+++ b/src/main/java/org/gradle/playframework/extensions/PlayExtension.java
@@ -1,9 +1,12 @@
 package org.gradle.playframework.extensions;
 
+import javax.inject.Inject;
+
 import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.playframework.extensions.internal.PlayMajorVersion;
 
 import static org.gradle.playframework.extensions.PlayPlatform.DEFAULT_PLAY_VERSION;
@@ -22,6 +25,7 @@ import static org.gradle.playframework.extensions.PlayPlatform.DEFAULT_PLAY_VERS
  *         javaVersion = JavaVersion.VERSION_1_9
  *     }
  *     injectedRoutesGenerator = true
+ *     prefixDependencies = false
  * }
  * </pre>
  */
@@ -29,14 +33,17 @@ public class PlayExtension {
 
     private final PlayPlatform platform;
     private final Property<Boolean> injectedRoutesGenerator;
+    private final Property<Boolean> prefixDependencies;
 
+    @Inject
     public PlayExtension(ObjectFactory objectFactory) {
         this.platform = objectFactory.newInstance(PlayPlatform.class, objectFactory);
         this.platform.getPlayVersion().convention(DEFAULT_PLAY_VERSION);
         this.platform.getJavaVersion().convention(JavaVersion.current());
         this.platform.getScalaVersion().convention(platform.getPlayVersion().map(playVersion -> PlayMajorVersion.forPlayVersion(playVersion).getDefaultScalaPlatform()));
-        this.injectedRoutesGenerator = objectFactory.property(Boolean.class);
-        injectedRoutesGenerator.convention(platform.getPlayVersion().map(playVersion -> !PlayMajorVersion.forPlayVersion(playVersion).hasSupportForStaticRoutesGenerator()));
+        this.injectedRoutesGenerator = objectFactory.property(Boolean.class)
+                .convention(platform.getPlayVersion().map(playVersion -> !PlayMajorVersion.forPlayVersion(playVersion).hasSupportForStaticRoutesGenerator()));
+        this.prefixDependencies = objectFactory.property(Boolean.class).convention(true);
     }
 
     /**
@@ -65,5 +72,14 @@ public class PlayExtension {
      */
     public Property<Boolean> getInjectedRoutesGenerator() {
         return injectedRoutesGenerator;
+    }
+
+    /**
+     * Returns the property configuring if the dependencies for the distribution should be prefixed.
+     *
+     * @return Property configuring the renaming of dependencies
+     */
+    public Property<Boolean> getPrefixDependencies() {
+        return prefixDependencies;
     }
 }


### PR DESCRIPTION
Relates to #159
- added `Property<Boolean>` to turn on-off dependency prefixing for the project distribution. Default to on for backwards compatibility
- added simple test to validate prefixing happens for a well known library (`com.typesafe.play`)
- updated documentation