### PR TITLE
Updating For Play 2.9.x Series

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "org.gradle.playframework"
-version = "0.14"
+version = "0.15"
 
 repositories {
     mavenCentral()

--- a/src/main/java/org/gradle/playframework/extensions/internal/PlayMajorVersion.java
+++ b/src/main/java/org/gradle/playframework/extensions/internal/PlayMajorVersion.java
@@ -14,7 +14,9 @@ public enum PlayMajorVersion {
     PLAY_2_5_X("2.5.x", true,"2.11"),
     PLAY_2_6_X("2.6.x", true, "2.12", "2.11"),
     PLAY_2_7_X("2.7.x", false, "2.13", "2.12", "2.11"),
-    PLAY_2_8_X("2.8.x", false, "2.13", "2.12");
+    PLAY_2_8_X("2.8.x", false, "2.13", "2.12"),
+    // https://www.playframework.com/documentation/3.0.x/Migration29#Scala-2.12-support-discontinued
+    PLAY_2_9_X("2.9.x", false, "2.13");
 
     private final String name;
     private final boolean supportForStaticRoutes;

--- a/src/main/java/org/gradle/playframework/plugins/PlayApplicationPlugin.java
+++ b/src/main/java/org/gradle/playframework/plugins/PlayApplicationPlugin.java
@@ -92,6 +92,7 @@ public class PlayApplicationPlugin implements Plugin<Project> {
             case PLAY_2_6_X:
             case PLAY_2_7_X:
             case PLAY_2_8_X:
+            case PLAY_2_9_X:
                 dependencies.add(PLATFORM_CONFIGURATION, playPlatform.getDependencyNotation("play-java-forms").get());
         }
     }

--- a/src/main/java/org/gradle/playframework/tools/internal/routes/DefaultVersionedRoutesCompilerAdapter.java
+++ b/src/main/java/org/gradle/playframework/tools/internal/routes/DefaultVersionedRoutesCompilerAdapter.java
@@ -1,14 +1,15 @@
 package org.gradle.playframework.tools.internal.routes;
 
 import java.util.Arrays;
+import org.gradle.playframework.util.VersionNumber;
 
 abstract class DefaultVersionedRoutesCompilerAdapter implements VersionedRoutesCompilerAdapter {
     private static final Iterable<String> SHARED_PACKAGES = Arrays.asList("play.router", "scala.collection", "scala.collection.mutable", "scala.util.matching", "play.routes.compiler");
-    private final String playVersion;
+    private final VersionNumber playVersion;
     private final String scalaVersion;
 
     public DefaultVersionedRoutesCompilerAdapter(String playVersion, String scalaVersion) {
-        this.playVersion = playVersion;
+        this.playVersion = VersionNumber.parse(playVersion);
         this.scalaVersion = scalaVersion;
     }
 
@@ -18,12 +19,18 @@ abstract class DefaultVersionedRoutesCompilerAdapter implements VersionedRoutesC
 
     @Override
     public String getDependencyNotation() {
-        if (playVersion.equals("2.7.4") || playVersion.equals("2.7.5")) {
+        if (playVersion.equals(VersionNumber.parse("2.7.4")) ||
+            playVersion.equals(VersionNumber.parse("2.7.5"))) {
             // this is a hack because of a Play Framework issue
             // See: https://github.com/playframework/playframework/issues/10333
             return "com.typesafe.play:routes-compiler_" + scalaVersion + ":2.7.3";
         }
-        return "com.typesafe.play:routes-compiler_" + scalaVersion + ":" + playVersion;
+
+        if (playVersion.isLowerThan(VersionNumber.parse("2.9.0"))) {
+            return "com.typesafe.play:routes-compiler_" + scalaVersion + ":" + playVersion;
+        }
+        // https://www.playframework.com/documentation/3.0.x/Migration29#Changed-artifact-names
+        return "com.typesafe.play:play-routes-compiler_" + scalaVersion + ":" + playVersion;
     }
 
     @Override

--- a/src/main/java/org/gradle/playframework/tools/internal/routes/RoutesCompilerFactory.java
+++ b/src/main/java/org/gradle/playframework/tools/internal/routes/RoutesCompilerFactory.java
@@ -25,6 +25,7 @@ public class RoutesCompilerFactory {
                 return new RoutesCompilerAdapterV24X(playVersion, scalaVersion);
             case PLAY_2_7_X:
             case PLAY_2_8_X:
+            case PLAY_2_9_X:
             default:
                 return new RoutesCompilerAdapterV27X(playVersion, scalaVersion);
         }

--- a/src/main/java/org/gradle/playframework/tools/internal/twirl/TwirlCompilerFactory.java
+++ b/src/main/java/org/gradle/playframework/tools/internal/twirl/TwirlCompilerFactory.java
@@ -21,8 +21,12 @@ public class TwirlCompilerFactory {
             case PLAY_2_6_X:
                 return new TwirlCompilerAdapterV13X("1.3.13", scalaCompatibilityVersion, playTwirlAdapter);
             case PLAY_2_7_X:
-            default:
+            case PLAY_2_8_X:
                 return new TwirlCompilerAdapterV13X("1.5.1", scalaCompatibilityVersion, playTwirlAdapter);
+            case PLAY_2_9_X:
+            default:
+                // https://www.playframework.com/documentation/3.0.x/Migration29#Updated-libraries
+                return new TwirlCompilerAdapterV13X("1.6.0", scalaCompatibilityVersion, playTwirlAdapter);
         }
     }
 
@@ -36,6 +40,7 @@ public class TwirlCompilerFactory {
             case PLAY_2_7_X:
                 return new PlayTwirlAdapterV26X();
             case PLAY_2_8_X:
+            case PLAY_2_9_X:
             default:
                 return new PlayTwirlAdapterV28X();
         }

--- a/src/main/java/org/gradle/playframework/util/VersionNumber.java
+++ b/src/main/java/org/gradle/playframework/util/VersionNumber.java
@@ -70,6 +70,14 @@ public class VersionNumber implements Comparable<VersionNumber> {
         return new VersionNumber(major, minor, micro, patch, null, scheme);
     }
 
+    public boolean isLowerThan(VersionNumber other) {
+        return this.compareTo(other) < 0;
+    }
+
+    public boolean isHigherThan(VersionNumber other) {
+        return this.compareTo(other) > 0;
+    }
+
     @Override
     public int compareTo(VersionNumber other) {
         if (major != other.major) {


### PR DESCRIPTION
Added support for 2.9.0+ versions of PlayFramwork

- Dropped support for Scala 2.12 in higher Play version enums
- DefaultVersionedRoutesCompiler uses VersionNumber for version fiddling
- Added isLowerThan, isHigherThan VersionNumber helpers
- 2.9.x routes have a renamed library
- Twirl version bumped to 1.6.0