### PR TITLE
Update Asciidoctor to 4.0.4

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -44,14 +44,16 @@ Importing the project into IntelliJ is straight forward. From the menu select _F
 The project currently doesn't define a release process that can be triggered by running a single task. Following the process below.
 
 1. Ensure the version in `build.gradle.kts` is updated to the new version to be published.
-2. Update the release notes and release date in link:./src/docs/asciidoc/50-changes.adoc[changelog file].
-3. Create a release on GitHub with the appropriate tag.
-4. Build and publish the Javadocs and the user guide by running the task `gitPublishPush`.
-5. Check that the https://github.com/gradle/playframework/actions?query=workflow%3A%22Create+Release%22 GitHub action is successful.
+2. Make sure you have a GH token for publishing the docs available.
+3. Test building the docs by running `:asciidoctor :javadoc` and verifying that the generated files in `build/docs/asciidoc` and `build/docs/javadoc` are correct.
+4. Update the release notes and release date in link:./src/docs/asciidoc/50-changes.adoc[changelog file].
+5. Create a release on GitHub with the appropriate tag.
+6. Build and publish the Javadocs and the user guide by running `:gitPublishPush -Dorg.ajoberstar.grgit.auth.username=$GH_TOKEN`.
+7. Check that the https://github.com/gradle/playframework/actions?query=workflow%3A%22Create+Release%22 GitHub action is successful.
 
 === Generating documentation
 
-The markup language for the user guide of this plugin is AsciiDoc. Documentation sources sit in the directory `src/docs`. To generate the HTML version of the plugin user guide, run the task `asciidoctor`. The generated HTML will be available in the directory `build/asciidoc/html5`.
+The markup language for the user guide of this plugin is AsciiDoc. Documentation sources sit in the directory `src/docs`. To generate the HTML version of the plugin user guide, run the task `asciidoctor`. The generated HTML will be available in the directory `build/asciidoc/html`.
 
 === Publishing documentation to GitHub Pages
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "org.gradle.playframework"
-version = "0.15"
+version = "0.16"
 
 repositories {
     mavenCentral()

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -18,10 +18,7 @@ dependencies {
     implementation(kotlin("gradle-plugin"))
     implementation("org.ajoberstar:gradle-git-publish:0.3.3")
 
-    implementation("org.asciidoctor:asciidoctor-gradle-plugin:1.6.1")
-    constraints {
-        implementation("org.ysb33r.gradle:grolifant:0.12.1")
-    }
+    implementation("org.asciidoctor:asciidoctor-gradle-jvm:4.0.4")
 }
 
 kotlinDslPluginOptions {

--- a/buildSrc/src/main/kotlin/org/gradle/playframework/GitHubPagesPlugin.kt
+++ b/buildSrc/src/main/kotlin/org/gradle/playframework/GitHubPagesPlugin.kt
@@ -2,7 +2,7 @@ package org.gradle.playframework
 
 import org.ajoberstar.gradle.git.publish.GitPublishExtension
 import org.ajoberstar.gradle.git.publish.GitPublishPlugin
-import org.asciidoctor.gradle.AsciidoctorTask
+import org.asciidoctor.gradle.jvm.AsciidoctorTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.javadoc.Javadoc

--- a/src/main/java/org/gradle/playframework/util/CollectionUtils.java
+++ b/src/main/java/org/gradle/playframework/util/CollectionUtils.java
@@ -58,6 +58,7 @@ public final class CollectionUtils {
      *
      * If a non null object cannot be cast to the target type, a ClassCastException will be thrown.
      *
+     * @param type Class token for the target type {@code <T>} in the flattened list
      * @param things The things to flatten
      * @param <T> The target type in the flattened list
      * @return A flattened list of the given things
@@ -121,6 +122,15 @@ public final class CollectionUtils {
         return set;
     }
 
+    /**
+     * Given a set of values, derive a set of keys and populate a map.
+     *
+     * @param destination The map to populate
+     * @param items The values to derive keys from
+     * @param keyGenerator The function to derive keys from the values
+     * @param <K> The type of the keys
+     * @param <V> The type of the values
+     */
     public static <K, V> void collectMap(Map<K, V> destination, Iterable<? extends V> items, Transformer<? extends K, ? super V> keyGenerator) {
         for (V item : items) {
             destination.put(keyGenerator.transform(item), item);
@@ -129,6 +139,12 @@ public final class CollectionUtils {
 
     /**
      * Given a set of values, derive a set of keys and return a map
+     *
+     * @param items The values to derive keys from
+     * @param keyGenerator The function to derive keys from the values
+     * @param <K> The type of the keys
+     * @param <V> The type of the values
+     * @return The resulting map of keys to values
      */
     public static <K, V> Map<K, V> collectMap(Iterable<? extends V> items, Transformer<? extends K, ? super V> keyGenerator) {
         Map<K, V> map = new LinkedHashMap<K, V>();

--- a/src/main/java/org/gradle/playframework/util/VersionNumber.java
+++ b/src/main/java/org/gradle/playframework/util/VersionNumber.java
@@ -119,6 +119,7 @@ public class VersionNumber implements Comparable<VersionNumber> {
 
     /**
      * Returns the default MAJOR.MINOR.MICRO-QUALIFIER scheme.
+     * @return the default scheme
      */
     public static VersionNumber.Scheme scheme() {
         return DEFAULT_SCHEME;
@@ -126,6 +127,7 @@ public class VersionNumber implements Comparable<VersionNumber> {
 
     /**
      * Returns the MAJOR.MINOR.MICRO.PATCH-QUALIFIER scheme.
+     * @return the scheme with patch number
      */
     public static VersionNumber.Scheme withPatchNumber() {
         return PATCH_SCHEME;


### PR DESCRIPTION
- Bumps project version to 0.15.1.
- Updates release instructions with new verification steps.
- Simplifies dependency versions: we're on grolifant 3.0.1 now, no need for constraint, no need for explicitly setting asciidocextension version in our plugin, we get 2.5.7 now.
- Update renamed Asciidoc types.
- Fixes Javadoc warnings and JDK warnings when running asciidoctor.